### PR TITLE
updated documentation of merge_samples

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -92,11 +92,15 @@ remove_iterations <- function(pmwg,select,remove=TRUE,last_select=FALSE,filter=N
 
 #' Merge samples
 #'
-#' Merges samples from all chains together as one unlisted object
+#' Merges samples from all chains as one unlisted object.
 #'
-#' @param samplers A list of samplers
+#' Note that all sampling stages are included in the merged output,
+#' including iterations from the `preburn`, `burn`, and `adapt` stages.
+#' `merge_samples(samplers)$samples$stage` shows the corresponding sampling stages.
 #'
-#' @return an unlisted sampler with all chains merged
+#' @param samplers A samplers object, commonly the output of `run_emc()`
+#'
+#' @return An unlisted samplers object with all chains merged
 #' @export
 #'
 merge_samples <- function(samplers){

--- a/man/merge_samples.Rd
+++ b/man/merge_samples.Rd
@@ -7,11 +7,16 @@
 merge_samples(samplers)
 }
 \arguments{
-\item{samplers}{A list of samplers}
+\item{samplers}{A samplers object, commonly the output of \code{run_emc()}}
 }
 \value{
-an unlisted sampler with all chains merged
+An unlisted samplers object with all chains merged
 }
 \description{
-Merges samples from all chains together as one unlisted object
+Merges samples from all chains as one unlisted object.
+}
+\details{
+Note that all sampling stages are included in the merged output,
+including iterations from the \code{preburn}, \code{burn}, and \code{adapt} stages.
+\code{merge_samples(samplers)$samples$stage} shows the corresponding sampling stages.
 }


### PR DESCRIPTION
Specifically added the following info: "Note that all sampling stages are included in the merged output, including iterations from the preburn, burn, and adapt stages. merge_samples(samplers)$samples$stage shows the corresponding sampling stages."