### PR TITLE
Ensure running SD never collapses

### DIFF
--- a/R/noisy_covariate.R
+++ b/R/noisy_covariate.R
@@ -145,7 +145,7 @@ running_moments <- function(new_latent, old_mu, old_sd, idx){
   new_var <- ((idx - 1)*(old_sd^2) + (delta^2 * idx / n_new)) / (n_new - 1)
   list(
     mu = meanNew,
-    sd   = min(sqrt(new_var), 0.01)
+    sd   = max(sqrt(new_var), 0.01)
   )
 }
 


### PR DESCRIPTION
## Summary
- keep variance alive in `running_moments()`

## Testing
- `devtools::test()` *(fails: dependencies `matrixcalc`, `WienR` unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6841d90d3e34832a846f66f134df6e2e