### PR TITLE
Make conditional DIC the default in compare()

### DIFF
--- a/R/statistics.R
+++ b/R/statistics.R
@@ -1,12 +1,14 @@
-#' Information Criteria and Marginal Likelihoods
+#' Information Criteria and Log Marginal Likelihood
 #'
-#' Returns the BPIC/DIC and optionally marginal deviance (-2*marginal likelihood) for a list of samples objects.
+#' Returns the BPIC/DIC and optionally marginal deviance (-2 x log marginal likelihood) for a list of samples objects.
 #'
-#' Computes DIC and BPIC using a joint deviance based on both the data likelihood and the hierarchical prior over subject-level parameters.
+#' Computes DIC and BPIC using a deviance based on either (a) the data likelihood
+#' only ("conditional", default) or (b) the joint likelihood including the
+#' hierarchical prior over subject-level parameters ("joint", experimental).
 #'
 #' If `use_best_fit = TRUE` (default), the deviance anchor is taken as the better
 #' of the deviance at the posterior mean parameters and the best-fitting posterior
-#' draw. If FALSE, only the deviance at the posterior mean parameters is used
+#' draw. If `FALSE`, the deviance at the posterior mean parameters is used
 #' (standard DIC/BPIC).
 #'
 #' @param sList List of samples objects
@@ -14,7 +16,10 @@
 #' @param filter An integer or vector. If it's an integer, iterations up until the value set by `filter` will be excluded.
 #' If a vector is supplied, only the iterations in the vector will be considered.
 #' @param use_best_fit Boolean; defaults to `TRUE` If `TRUE`, uses the smaller of (i) the deviance at the posterior mean parameters and (ii) the lowest deviance across posterior draws (i.e., the best-fitting draw). If `FALSE`, uses only the deviance at the posterior mean parameters (i.e., standard DIC/BPIC).
-#' @param BayesFactor Boolean, defaults to `TRUE`. Include marginal likelihoods as estimated using WARP-III bridge sampling.
+#' @param type Character. `"conditional"` (default) uses only the data likelihood
+#' for DIC/BPIC. `"joint"` uses the joint likelihood including the hierarchical
+#' prior; this option is experimental.
+#' @param BayesFactor Boolean, defaults to `TRUE`. Include log marginal likelihoods as estimated using WARP-III bridge sampling.
 #' Usually takes a minute per model added to calculate
 #' @param cores_for_props Integer, how many cores to use for the Bayes factor calculation, here 4 is the default for the 4 different proposal densities to evaluate, only 1, 2 and 4 are sensible.
 #' @param cores_per_prop Integer, how many cores to use for the Bayes factor calculation if you have more than 4 cores available. Cores used will be cores_for_props * cores_per_prop. Best to prioritize cores_for_props being 4 or 2
@@ -51,8 +56,10 @@
 #' @export
 
 compare <- function(sList,stage="sample",filter=NULL,use_best_fit=TRUE,
+                        type = "conditional",
                         BayesFactor = TRUE, cores_for_props =4, cores_per_prop = 1,
                         print_summary=TRUE,digits=0,digits_p=3, ...) {
+  type <- match.arg(type, c("conditional","joint"))
   if(is(sList, "emc")) sList <- list(sList)
   getp <- function(IC) {
     IC <- -(IC - min(IC))/2
@@ -66,7 +73,7 @@ compare <- function(sList,stage="sample",filter=NULL,use_best_fit=TRUE,
   ICs <- setNames(vector(mode="list",length=length(sList)),names(sList))
   for (i in 1:length(ICs)) ICs[[i]] <- IC(sList[[i]],stage=stage,
                                           filter=sflist[[i]],use_best_fit=use_best_fit,subject=list(...)$subject,print_summary=FALSE,
-                                          group_only = dots$group_only)
+                                          group_only = dots$group_only, type = type)
   ICs <- data.frame(do.call(rbind,ICs))
   DICp <- getp(ICs$DIC)
   BPICp <- getp(ICs$BPIC)
@@ -256,9 +263,10 @@ gelman_diag_robust <- function(mcl,autoburnin = FALSE,transform = TRUE, omit_mps
 
 IC <- function(emc,stage="sample",filter=0,use_best_fit=TRUE,
                print_summary=TRUE,digits=0,subject=NULL,
-               group_only = FALSE)
+               group_only = FALSE, type = "conditional")
   # Gets DIC, BPIC, effective parameters, mean deviance, and deviance of mean
 {
+  type <- match.arg(type, c("conditional","joint"))
   # Mean log-likelihood for each subject
   if (length(subject)!=1) {
     ll <- get_pars(emc, stage = stage, filter = filter, selection = "LL", merge_chains = TRUE)
@@ -282,7 +290,7 @@ IC <- function(emc,stage="sample",filter=0,use_best_fit=TRUE,
     Dmeans <- Dmeans[subject[1]]
     mean_lls <- mean_lls[subject[1]]
     minDs <- minDs[subject[1]]
-  } else{
+  } else if (type == "joint"){
     group_stats <- group_IC(emc, stage=stage,filter=filter, type = emc[[1]]$type)
     if(group_only){
       mean_lls <- group_stats$mean_ll
@@ -293,6 +301,8 @@ IC <- function(emc,stage="sample",filter=0,use_best_fit=TRUE,
       minDs <- c(minDs, group_stats$minD)
       Dmeans <- c(Dmeans, group_stats$Dmean)
     }
+  } else if (group_only) {
+    warning("group_only ignored for conditional DIC; using data likelihood only.")
   }
   if (use_best_fit) minDs <- pmin(minDs,Dmeans)
 
@@ -635,4 +645,3 @@ model_averaging <- function(IC_for, IC_against) {
     Factor = bayes_factor
   ))
 }
-

--- a/R/statistics.R
+++ b/R/statistics.R
@@ -4,7 +4,7 @@
 #'
 #' Computes DIC and BPIC using a deviance based on either (a) the data likelihood
 #' only ("conditional", default) or (b) the joint likelihood including the
-#' hierarchical prior over subject-level parameters ("joint", experimental).
+#' hierarchical prior over subject-level parameters ("joint", non-standard, experimental).
 #'
 #' If `use_best_fit = TRUE` (default), the deviance anchor is taken as the better
 #' of the deviance at the posterior mean parameters and the best-fitting posterior
@@ -19,7 +19,8 @@
 #' @param type Character. `"conditional"` (default) uses only the data likelihood
 #' for DIC/BPIC. `"joint"` uses the joint likelihood including the hierarchical
 #' prior; this option is experimental.
-#' @param BayesFactor Boolean, defaults to `TRUE`. Include log marginal likelihoods as estimated using WARP-III bridge sampling.
+#' @param BayesFactor Boolean, defaults to `TRUE`. Include marginal deviance
+#' (`-2 * log` marginal likelihood) as estimated using WARP-III bridge sampling.
 #' Usually takes a minute per model added to calculate
 #' @param cores_for_props Integer, how many cores to use for the Bayes factor calculation, here 4 is the default for the 4 different proposal densities to evaluate, only 1, 2 and 4 are sensible.
 #' @param cores_per_prop Integer, how many cores to use for the Bayes factor calculation if you have more than 4 cores available. Cores used will be cores_for_props * cores_per_prop. Best to prioritize cores_for_props being 4 or 2

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -33,7 +33,8 @@ If a vector is supplied, only the iterations in the vector will be considered.}
 for DIC/BPIC. \code{"joint"} uses the joint likelihood including the hierarchical
 prior; this option is experimental.}
 
-\item{BayesFactor}{Boolean, defaults to \code{TRUE}. Include log marginal likelihoods as estimated using WARP-III bridge sampling.
+\item{BayesFactor}{Boolean, defaults to \code{TRUE}. Include marginal deviance
+(\code{-2 * log} marginal likelihood) as estimated using WARP-III bridge sampling.
 Usually takes a minute per model added to calculate}
 
 \item{cores_for_props}{Integer, how many cores to use for the Bayes factor calculation, here 4 is the default for the 4 different proposal densities to evaluate, only 1, 2 and 4 are sensible.}
@@ -58,7 +59,7 @@ Returns the BPIC/DIC and optionally marginal deviance (-2 x log marginal likelih
 \details{
 Computes DIC and BPIC using a deviance based on either (a) the data likelihood
 only ("conditional", default) or (b) the joint likelihood including the
-hierarchical prior over subject-level parameters ("joint", experimental).
+hierarchical prior over subject-level parameters ("joint", non-standard, experimental).
 
 If \code{use_best_fit = TRUE} (default), the deviance anchor is taken as the better
 of the deviance at the posterior mean parameters and the best-fitting posterior

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/statistics.R
 \name{compare}
 \alias{compare}
-\title{Information Criteria and Marginal Likelihoods}
+\title{Information Criteria and Log Marginal Likelihood}
 \usage{
 compare(
   sList,
   stage = "sample",
   filter = NULL,
   use_best_fit = TRUE,
+  type = "conditional",
   BayesFactor = TRUE,
   cores_for_props = 4,
   cores_per_prop = 1,
@@ -28,7 +29,11 @@ If a vector is supplied, only the iterations in the vector will be considered.}
 
 \item{use_best_fit}{Boolean; defaults to \code{TRUE} If \code{TRUE}, uses the smaller of (i) the deviance at the posterior mean parameters and (ii) the lowest deviance across posterior draws (i.e., the best-fitting draw). If \code{FALSE}, uses only the deviance at the posterior mean parameters (i.e., standard DIC/BPIC).}
 
-\item{BayesFactor}{Boolean, defaults to \code{TRUE}. Include marginal likelihoods as estimated using WARP-III bridge sampling.
+\item{type}{Character. \code{"conditional"} (default) uses only the data likelihood
+for DIC/BPIC. \code{"joint"} uses the joint likelihood including the hierarchical
+prior; this option is experimental.}
+
+\item{BayesFactor}{Boolean, defaults to \code{TRUE}. Include log marginal likelihoods as estimated using WARP-III bridge sampling.
 Usually takes a minute per model added to calculate}
 
 \item{cores_for_props}{Integer, how many cores to use for the Bayes factor calculation, here 4 is the default for the 4 different proposal densities to evaluate, only 1, 2 and 4 are sensible.}
@@ -48,14 +53,16 @@ Matrix of effective number of parameters, mean deviance, deviance of
 mean, DIC, BPIC, Marginal Deviance (if \code{BayesFactor=TRUE}) and associated weights.
 }
 \description{
-Returns the BPIC/DIC and optionally marginal deviance (-2*marginal likelihood) for a list of samples objects.
+Returns the BPIC/DIC and optionally marginal deviance (-2 x log marginal likelihood) for a list of samples objects.
 }
 \details{
-Computes DIC and BPIC using a joint deviance based on both the data likelihood and the hierarchical prior over subject-level parameters.
+Computes DIC and BPIC using a deviance based on either (a) the data likelihood
+only ("conditional", default) or (b) the joint likelihood including the
+hierarchical prior over subject-level parameters ("joint", experimental).
 
 If \code{use_best_fit = TRUE} (default), the deviance anchor is taken as the better
 of the deviance at the posterior mean parameters and the best-fitting posterior
-draw. If FALSE, only the deviance at the posterior mean parameters is used
+draw. If \code{FALSE}, the deviance at the posterior mean parameters is used
 (standard DIC/BPIC).
 }
 \examples{

--- a/tests/testthat/_snaps/Darwin/variant_funs.md
+++ b/tests/testthat/_snaps/Darwin/variant_funs.md
@@ -34,7 +34,7 @@
       compare(list(diag = LNR_diag), stage = "preburn", cores_for_props = 1)
     Output
              MD wMD  DIC wDIC BPIC wBPIC EffectiveN meanD Dmean minD
-      diag -579   1 1112    1 2009     1        897   215  -607 -682
+      diag -579   1 1090    1 1965     1        875   215  -614 -661
 
 # run_blocked
 
@@ -72,7 +72,7 @@
       compare(list(blocked = LNR_blocked), stage = "preburn", cores_for_props = 1)
     Output
                 MD wMD  DIC wDIC  BPIC wBPIC EffectiveN meanD Dmean minD
-      blocked -527   1 6489    1 10075     1       3585  2904  -611 -681
+      blocked -527   1 6464    1 10029     1       3565  2899  -620 -665
 
 # run_single
 

--- a/tests/testthat/_snaps/compare.md
+++ b/tests/testthat/_snaps/compare.md
@@ -4,7 +4,7 @@
       compare(list(samples_LNR), cores_for_props = 1)
     Output
           MD wMD  DIC wDIC BPIC wBPIC EffectiveN meanD Dmean minD
-      1 -571   1 -607    1 -566     1         41  -648  -656 -690
+      1 -571   1 -621    1 -606     1         15  -636  -648 -651
 
 # savage-dickey
 


### PR DESCRIPTION

## Summary

This PR updates `compare()` so conditional DIC/BPIC is now the default.

Previously, DIC/BPIC were computed using the joint deviance, i.e. the data likelihood plus the hierarchical prior over subject-level parameters. This PR adds a `type` argument:

- `type = "conditional"`: default; uses only the subject-level data likelihood
- `type = "joint"`: keeps the previous joint behavior, labelled as experimental

The conditional version is the usual DIC based on \(p(y_s \mid \alpha_s)\), while the joint version additionally includes the group-level prior contribution \(p(\alpha_{1:S} \mid \phi)\).

## Details

- Added `type = "conditional"` to `compare()`.
- Passed `type` through to the internal `IC()` function.
- Updated `IC()` so `group_IC()` is only used when `type = "joint"`.
- Kept the existing `use_best_fit` behavior unchanged.
- Clarified the help text around marginal deviance: it is `-2 * log` marginal likelihood, not `-2 * marginal likelihood`.
- Updated `man/compare.Rd` to match the roxygen docs.

## Notes

`type = "joint"` preserves the old behavior, but is now marked as experimental because it includes the hierarchical prior term in the deviance.

The default `use_best_fit = TRUE` behavior is unchanged. For textbook DIC/BPIC, users can still set `use_best_fit = FALSE`.
