### PR TITLE
Feature: Add time info to messages

### DIFF
--- a/R/fitting.R
+++ b/R/fitting.R
@@ -13,18 +13,20 @@ format_duration <- function(dt) {
 # Remaining time across all stages, based on the duration of the *last* try
 # Stage assumptions:
 #   preburn: 1-1
-#   burn: 1-max_tries
-#   adapt: 1-2
-#   sample: 10-max_tries
-estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tries = 20L) {
+#   burn   : 1-max_tries
+#   adapt  : 1-2
+#   sample : 10-max_tries
+estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tries = 20L,
+                                          current_iters = NULL, target_iters = NULL,
+                                          step_size = NULL) {
   stage_order <- c("preburn", "burn", "adapt", "sample")
 
+  min_total <- c(preburn = 1L, burn = 1L, adapt = 1L, sample = 10L)
+  max_total <- c(preburn = 1L, burn = max_tries, adapt = 2L, sample = max_tries)
+
   if (!stage %in% stage_order) {
-    # Fallback: only this stage, 1-max_tries
-    min_total <- 1L
-    max_total <- max_tries
-    min_rem_tries <- max(0L, min_total - tries_done)
-    max_rem_tries <- max(0L, max_total - tries_done)
+    min_rem_tries <- max(0L, 1L - tries_done)
+    max_rem_tries <- max(0L, max_tries - tries_done)
     return(list(
       min_time = min_rem_tries * elapsed_dt,
       max_time = max_rem_tries * elapsed_dt
@@ -33,28 +35,9 @@ estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tri
 
   idx <- match(stage, stage_order)
 
-  # Exact per-stage min/max tries
-  min_total <- c(
-    preburn = 1L,
-    burn    = 1L,
-    adapt   = 1L,
-    sample  = 10L
-  )
-
-  max_total <- c(
-    preburn= 1L,          # exactly 1
-    burn= max_tries,   # 1-20
-    adapt= 2L,          # 1-2 usually
-    sample = max_tries    # 10-20
-  )
-
-  # Remaining in the current stage
-  min_current_rem <- max(0L, min_total[stage] - tries_done)
-  max_current_rem <- max(0L, max_total[stage] - tries_done)
-
-  # Remaining in all later stages
+  # --- Remaining in later stages (always try-count based) ---
   if (idx < length(stage_order)) {
-    later_stages <- stage_order[(idx + 1L):length(stage_order)]
+    later_stages  <- stage_order[(idx + 1L):length(stage_order)]
     min_later_rem <- sum(min_total[later_stages])
     max_later_rem <- sum(max_total[later_stages])
   } else {
@@ -62,13 +45,24 @@ estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tri
     max_later_rem <- 0L
   }
 
-  min_tries_rem <- min_current_rem + min_later_rem
-  max_tries_rem <- max_current_rem + max_later_rem
+  # --- Remaining in current stage ---
+  max_current_rem <- max(0L, max_total[stage] - tries_done)
 
-  list(
-    min_time = min_tries_rem * elapsed_dt,
-    max_time = max_tries_rem * elapsed_dt
-  )
+  # For sample stage: use iteration-based minimum if we have the info
+  if (stage == "sample" &&
+      !is.null(current_iters) && !is.null(target_iters) && !is.null(step_size)) {
+    iters_remaining   <- max(0L, target_iters - current_iters)
+    time_per_iter     <- elapsed_dt / step_size
+    min_current_time  <- iters_remaining * time_per_iter
+    min_time <- min_current_time + min_later_rem * elapsed_dt
+  } else {
+    min_current_rem <- max(0L, min_total[stage] - tries_done)
+    min_time <- (min_current_rem + min_later_rem) * elapsed_dt
+  }
+
+  max_time <- (max_current_rem + max_later_rem) * elapsed_dt
+
+  list(min_time = min_time, max_time = max_time)
 }
 
 get_stop_criteria <- function(stage, stop_criteria, type){
@@ -229,14 +223,21 @@ run_emc <- function(emc, stage, stop_criteria,
       gd <- progress$gd$gd
       gd_message <- NULL
       if(!is.null(stop_criteria$mean_gd)) gd_message <- paste0("Mean Rhat=", round(mean(gd), 3))
-      if(!is.null(stop_criteria$max_gd))  gd_message <- paste0("Max Rhat=", round(max(gd), 3))
-      rem <- estimate_remaining_total_time(stage=stage, tries_done=progress$trys, elapsed_dt=elapsed, max_tries=max_tries)
+      if(!is.null(stop_criteria$max_gd)) gd_message <- paste0("Max Rhat=", round(max(gd), 3))
+
+      # Get current iteration count for the sample stage
+      current_iters <- if (stage == "sample") chain_n(emc)[1, stage] else NULL
+      target_iters  <- if (stage == "sample") stop_criteria[["iter"]] else NULL
+
+      rem <- estimate_remaining_total_time(stage= stage,tries_done = progress$trys, elapsed_dt = elapsed, max_tries = max_tries,
+                                           current_iters = current_iters, target_iters = target_iters, step_size = progress$step_size)
+      #      rem <- estimate_remaining_total_time(stage=stage, tries_done=progress$trys, elapsed_dt=elapsed, max_tries=max_tries)
       message(sprintf("[%s | try=%d | iters=%d%s] Duration: %s - ETA: %s-%s",
-        stage, progress$trys, progress$total_iters,
-        ifelse(!is.null(gd_message), paste0(" | ", gd_message), ""),
-        format_duration(elapsed),
-        format_duration(rem$min_time),
-        format_duration(rem$max_time)))
+                      stage, progress$trys, progress$total_iters,
+                      ifelse(!is.null(gd_message), paste0(" | ", gd_message), ""),
+                      format_duration(elapsed),
+                      format_duration(rem$min_time),
+                      format_duration(rem$max_time)))
     }
   }
   emc <- strip_duplicates(emc)

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -229,8 +229,7 @@ run_emc <- function(emc, stage, stop_criteria,
       gd <- progress$gd$gd
       gd_message <- NULL
       if(!is.null(stop_criteria$mean_gd)) gd_message <- paste0("Mean Rhat=", round(mean(gd), 3))
-      if(!is.null(stop_criteria$max_gd)) gd_message <- paste0("Max Rhat=", round(mean(gd), 3))
-      rem <- estimate_remaining_total_time(stage = stage,tries_done = progress$trys, elapsed_dt = elapsed, max_tries = max_tries)
+      if(!is.null(stop_criteria$max_gd))  gd_message <- paste0("Max Rhat=", round(mean(gd), 3))
       rem <- estimate_remaining_total_time(stage=stage, tries_done=progress$trys, elapsed_dt=elapsed, max_tries=max_tries)
       message(sprintf("[%s | try=%d | iters=%d%s] Duration: %s - ETA: %s-%s",
         stage, progress$trys, progress$total_iters,

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -12,15 +12,15 @@ format_duration <- function(dt) {
 
 # Remaining time across all stages, based on the duration of the *last* try
 # Stage assumptions:
-#   preburn: 1–1
-#   burn   : 1–max_tries
-#   adapt  : 1–2
-#   sample : 10–max_tries
+#   preburn: 1-1
+#   burn: 1-max_tries
+#   adapt: 1-2
+#   sample: 10-max_tries
 estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tries = 20L) {
   stage_order <- c("preburn", "burn", "adapt", "sample")
 
   if (!stage %in% stage_order) {
-    # Fallback: only this stage, 1–max_tries
+    # Fallback: only this stage, 1-max_tries
     min_total <- 1L
     max_total <- max_tries
     min_rem_tries <- max(0L, min_total - tries_done)
@@ -42,10 +42,10 @@ estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tri
   )
 
   max_total <- c(
-    preburn = 1L,          # exactly 1
-    burn    = max_tries,   # 1–20
-    adapt   = 2L,          # 1–2 usually
-    sample  = max_tries    # 10–20
+    preburn= 1L,          # exactly 1
+    burn= max_tries,   # 1-20
+    adapt= 2L,          # 1-2 usually
+    sample = max_tries    # 10-20
   )
 
   # Remaining in the current stage
@@ -233,7 +233,7 @@ run_emc <- function(emc, stage, stop_criteria,
         max_tries  = max_tries
       )
       message(sprintf(
-        "[%s | try=%d | iters=%d] Duration: %s — ETA: %s–%s",
+        "[%s | try=%d | iters=%d] Duration: %s - ETA: %s-%s",
         stage, progress$trys, progress$total_iters,
         format_duration(elapsed),
         format_duration(rem$min_time),

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -1,3 +1,76 @@
+# Nicely format a difftime (seconds / minutes / hours)
+format_duration <- function(dt) {
+  secs <- as.numeric(dt, units = "secs")
+  if (secs < 60) {
+    sprintf("%.1f s", secs)
+  } else if (secs < 3600) {
+    sprintf("%.1f min", secs / 60)
+  } else {
+    sprintf("%.1f h", secs / 3600)
+  }
+}
+
+# Remaining time across all stages, based on the duration of the *last* try
+# Stage assumptions:
+#   preburn: 1–1
+#   burn   : 1–max_tries
+#   adapt  : 1–2
+#   sample : 10–max_tries
+estimate_remaining_total_time <- function(stage, tries_done, elapsed_dt, max_tries = 20L) {
+  stage_order <- c("preburn", "burn", "adapt", "sample")
+
+  if (!stage %in% stage_order) {
+    # Fallback: only this stage, 1–max_tries
+    min_total <- 1L
+    max_total <- max_tries
+    min_rem_tries <- max(0L, min_total - tries_done)
+    max_rem_tries <- max(0L, max_total - tries_done)
+    return(list(
+      min_time = min_rem_tries * elapsed_dt,
+      max_time = max_rem_tries * elapsed_dt
+    ))
+  }
+
+  idx <- match(stage, stage_order)
+
+  # Exact per-stage min/max tries
+  min_total <- c(
+    preburn = 1L,
+    burn    = 1L,
+    adapt   = 1L,
+    sample  = 10L
+  )
+
+  max_total <- c(
+    preburn = 1L,          # exactly 1
+    burn    = max_tries,   # 1–20
+    adapt   = 2L,          # 1–2 usually
+    sample  = max_tries    # 10–20
+  )
+
+  # Remaining in the current stage
+  min_current_rem <- max(0L, min_total[stage] - tries_done)
+  max_current_rem <- max(0L, max_total[stage] - tries_done)
+
+  # Remaining in all later stages
+  if (idx < length(stage_order)) {
+    later_stages <- stage_order[(idx + 1L):length(stage_order)]
+    min_later_rem <- sum(min_total[later_stages])
+    max_later_rem <- sum(max_total[later_stages])
+  } else {
+    min_later_rem <- 0L
+    max_later_rem <- 0L
+  }
+
+  min_tries_rem <- min_current_rem + min_later_rem
+  max_tries_rem <- max_current_rem + max_later_rem
+
+  list(
+    min_time = min_tries_rem * elapsed_dt,
+    max_time = max_tries_rem * elapsed_dt
+  )
+}
+
 get_stop_criteria <- function(stage, stop_criteria, type){
   if(is.null(stop_criteria)){
     if(stage == "preburn"){
@@ -124,7 +197,7 @@ run_emc <- function(emc, stage, stop_criteria,
                              particle_factor=particle_factor,search_width=search_width,
                              n_cores=cores_per_chain, mc.cores = cores_for_chains,
                              r_cores = r_cores)
-    if(getOption("emc2.print_iteration_duration", TRUE)) { print(Sys.time()-t0) }
+
     class(sub_emc) <- "emc"
     if(cores_for_chains > 1) sub_emc <- pointer_reset_wrapper(sub_emc, emc)
     if(stage != 'preburn'){
@@ -149,6 +222,23 @@ run_emc <- function(emc, stage, stop_criteria,
       class(emc) <- "emc"
       save(emc, file = fileName)
       emc <- restore_duplicates(emc)
+    }
+
+    elapsed <- Sys.time() - t0
+    if (verbose) {
+      rem <- estimate_remaining_total_time(
+        stage      = stage,
+        tries_done = progress$trys,
+        elapsed_dt = elapsed,
+        max_tries  = max_tries
+      )
+      message(sprintf(
+        "[%s | try=%d | iters=%d] Duration: %s — ETA: %s–%s",
+        stage, progress$trys, progress$total_iters,
+        format_duration(elapsed),
+        format_duration(rem$min_time),
+        format_duration(rem$max_time)
+      ))
     }
   }
   emc <- strip_duplicates(emc)
@@ -211,8 +301,9 @@ check_progress <- function (emc, stage, iter, stop_criteria,
   else {
     iters_total <- progress$iters_total + step_size
     trys <- progress$trys + 1
-    if (verbose)
-      message(trys, ": Iterations ", stage, " = ", total_iters_stage)
+    # now in run_emc
+    # if (verbose)
+    #   message(trys, ": Iterations ", stage, " = ", total_iters_stage)
   }
   gd <- check_gd(emc, stage, stop_criteria[["max_gd"]], stop_criteria[["mean_gd"]], trys, verbose,
                  iter = total_iters_stage, selection, omit_mpsrf = stop_criteria[["omit_mpsrf"]],
@@ -263,7 +354,8 @@ check_progress <- function (emc, stage, iter, stop_criteria,
     }
   }
   return(list(emc = gd$emc, done = done, step_size = step_size,
-              trys = trys, n_blocks = gd$n_blocks))
+              trys = trys, n_blocks = gd$n_blocks,
+              total_iters_stage=total_iters_stage))
 }
 
 check_gd <- function(emc, stage, max_gd, mean_gd, omit_mpsrf, trys, verbose,

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -231,6 +231,7 @@ run_emc <- function(emc, stage, stop_criteria,
       if(!is.null(stop_criteria$mean_gd)) gd_message <- paste0("Mean Rhat=", round(mean(gd), 3))
       if(!is.null(stop_criteria$max_gd)) gd_message <- paste0("Max Rhat=", round(mean(gd), 3))
       rem <- estimate_remaining_total_time(stage = stage,tries_done = progress$trys, elapsed_dt = elapsed, max_tries = max_tries)
+      rem <- estimate_remaining_total_time(stage=stage, tries_done=progress$trys, elapsed_dt=elapsed, max_tries=max_tries)
       message(sprintf("[%s | try=%d | iters=%d%s] Duration: %s - ETA: %s-%s",
         stage, progress$trys, progress$total_iters,
         ifelse(!is.null(gd_message), paste0(" | ", gd_message), ""),

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -226,19 +226,17 @@ run_emc <- function(emc, stage, stop_criteria,
 
     elapsed <- Sys.time() - t0
     if (verbose) {
-      rem <- estimate_remaining_total_time(
-        stage      = stage,
-        tries_done = progress$trys,
-        elapsed_dt = elapsed,
-        max_tries  = max_tries
-      )
-      message(sprintf(
-        "[%s | try=%d | iters=%d] Duration: %s - ETA: %s-%s",
+      gd <- progress$gd$gd
+      gd_message <- NULL
+      if(!is.null(stop_criteria$mean_gd)) gd_message <- paste0("Mean Rhat=", round(mean(gd), 3))
+      if(!is.null(stop_criteria$max_gd)) gd_message <- paste0("Max Rhat=", round(mean(gd), 3))
+      rem <- estimate_remaining_total_time(stage = stage,tries_done = progress$trys, elapsed_dt = elapsed, max_tries = max_tries)
+      message(sprintf("[%s | try=%d | iters=%d%s] Duration: %s - ETA: %s-%s",
         stage, progress$trys, progress$total_iters,
+        ifelse(!is.null(gd_message), paste0(" | ", gd_message), ""),
         format_duration(elapsed),
         format_duration(rem$min_time),
-        format_duration(rem$max_time)
-      ))
+        format_duration(rem$max_time)))
     }
   }
   emc <- strip_duplicates(emc)
@@ -305,7 +303,7 @@ check_progress <- function (emc, stage, iter, stop_criteria,
     # if (verbose)
     #   message(trys, ": Iterations ", stage, " = ", total_iters_stage)
   }
-  gd <- check_gd(emc, stage, stop_criteria[["max_gd"]], stop_criteria[["mean_gd"]], trys, verbose,
+  gd <- check_gd(emc, stage, stop_criteria[["max_gd"]], stop_criteria[["mean_gd"]], trys, verbose=FALSE,
                  iter = total_iters_stage, selection, omit_mpsrf = stop_criteria[["omit_mpsrf"]],
                  n_blocks)
   iter_done <- ifelse(is.null(iter) || length(iter) == 0, TRUE, total_iters_stage >= iter)
@@ -355,6 +353,7 @@ check_progress <- function (emc, stage, iter, stop_criteria,
   }
   return(list(emc = gd$emc, done = done, step_size = step_size,
               trys = trys, n_blocks = gd$n_blocks,
+              gd=gd,
               total_iters_stage=total_iters_stage))
 }
 

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -229,7 +229,7 @@ run_emc <- function(emc, stage, stop_criteria,
       gd <- progress$gd$gd
       gd_message <- NULL
       if(!is.null(stop_criteria$mean_gd)) gd_message <- paste0("Mean Rhat=", round(mean(gd), 3))
-      if(!is.null(stop_criteria$max_gd))  gd_message <- paste0("Max Rhat=", round(mean(gd), 3))
+      if(!is.null(stop_criteria$max_gd))  gd_message <- paste0("Max Rhat=", round(max(gd), 3))
       rem <- estimate_remaining_total_time(stage=stage, tries_done=progress$trys, elapsed_dt=elapsed, max_tries=max_tries)
       message(sprintf("[%s | try=%d | iters=%d%s] Duration: %s - ETA: %s-%s",
         stage, progress$trys, progress$total_iters,


### PR DESCRIPTION
I often start running a model, and find myself wondering whether I have time to (a) pee, (b) make coffee, (c) go for a bike ride, (d) sleep. I created a little timer that gives the last-iteration duration, and makes a rough estimate of the total time remaining based on the stage & max_tries. It is obviously coarse because it can't know when the sampler will reach convergence, but it just gives a min and max duration based on the minimum number of samples and maximum number of tries. So just a ballpark estimate.

Example output:
```
Running preburn stage
[preburn | try=1 | iters=50] Duration: 1.9 s - ETA: 23.0 s-1.3 min
Running burn stage
[burn | try=1 | iters=100 | Mean Rhat=1.072] Duration: 2.0 s - ETA: 21.6 s-1.3 min
Running adapt stage
Enough unique values detected: 150
Testing proposal distribution creation
Successfully adapted - stopping adaptation
[adapt | try=1 | iters=100] Duration: 1.9 s - ETA: 19.3 s-40.6 s
Running sample stage
[sample | try=1 | iters=100 | Max Rhat=1.03] Duration: 2.2 s - ETA: 19.7 s-41.6 s
[sample | try=2 | iters=200 | Max Rhat=1.015] Duration: 1.0 s - ETA: 8.1 s-18.3 s
[sample | try=3 | iters=300 | Max Rhat=1.018] Duration: 0.9 s - ETA: 6.5 s-15.7 s
[sample | try=4 | iters=400 | Max Rhat=1.014] Duration: 0.9 s - ETA: 5.6 s-14.9 s
[sample | try=5 | iters=500 | Max Rhat=1.009] Duration: 1.0 s - ETA: 4.8 s-14.5 s
[sample | try=6 | iters=600 | Max Rhat=1.012] Duration: 1.0 s - ETA: 3.9 s-13.8 s
[sample | try=7 | iters=700 | Max Rhat=1.032] Duration: 1.3 s - ETA: 3.9 s-17.0 s
[sample | try=8 | iters=800 | Max Rhat=1.027] Duration: 1.1 s - ETA: 2.1 s-12.8 s
[sample | try=9 | iters=900 | Max Rhat=1.024] Duration: 1.0 s - ETA: 1.0 s-11.3 s
[sample | try=10 | iters=1000 | Max Rhat=1.016] Duration: 1.1 s - ETA: 0.0 s-10.6 s
Time difference of 17.96133 secs

```

edit: updated to merge time/iteration with Rhat messages, so just 1 output per try