### PR TITLE
Add Q-value reset support for delta kernels

### DIFF
--- a/R/trend.R
+++ b/R/trend.R
@@ -57,6 +57,15 @@ run_kernel_custom <- function(trend_pars = NULL, input, funptr, at_factor = NULL
 #'        If `TRUE`, missing values are forward-filled using the last known non-`NA` value after
 #'        applying the kernel. If `FALSE`, trials with missing covariates contribute `0` instead.
 #'        The default (NULL) is interpreted as `TRUE` for delta-rule models and `FALSE` otherwise.
+#' @param kernel_args Optional named list of kernel-specific arguments, aligned with \code{par_names}.
+#'   Can be \code{NULL} (no arguments) or a single named list applied to all parameters.
+#'   Currently supported arguments:
+#'   \describe{
+#'     \item{\code{q_reset_column}}{For delta-family kernels (\code{"delta"}, \code{"delta2kernel"},
+#'       \code{"delta2lr"}) only. Name of a logical or integer column in \code{data} indicating
+#'       trials on which the Q-value should be reset to \code{q0} before the prediction error
+#'       is computed. \code{TRUE}/\code{1} triggers a reset; \code{FALSE}/\code{0} does not.}
+#'   }
 #'
 #' @return A list containing the trend specifications for each parameter
 #' @export
@@ -206,7 +215,8 @@ make_trend <- function(par_names, cov_names = NULL, kernels, bases = NULL,
                        par_input = NULL, at = 'lR',
                        maps = NULL,
                        custom_trend = NULL,
-                       ffill_na = NULL){
+                       ffill_na = NULL,
+                       kernel_args = NULL){
   if(!(length(par_names) == length(kernels))){
     stop("Make sure that par_names and kernels have the same length")
   }
@@ -260,6 +270,42 @@ make_trend <- function(par_names, cov_names = NULL, kernels, bases = NULL,
   if(length(maps) > 0) {
     maps <- normalize_maps(maps, par_names)
   }
+
+  # Normalize kernel_args
+  if (is.null(kernel_args)) {
+    kernel_args <- rep(list(NULL), length(par_names))
+  } else if (!is.list(kernel_args)) {
+    stop("kernel_args must be NULL or a list")
+  } else {
+    # Distinguish list(q_reset_column='x')  [flat, single-kernel args]
+    # from           list(list(...), list(...))  [already per-kernel]
+    # Heuristic: if the top-level list has any named non-list elements,
+    # or all elements are named and none are lists, treat as a single entry.
+    is_flat <- !is.null(names(kernel_args)) && !any(vapply(kernel_args, is.list, logical(1)))
+    if (is_flat) {
+      kernel_args <- rep(list(kernel_args), length(par_names))
+    } else if (length(kernel_args) != length(par_names)) {
+      stop("kernel_args must be NULL, a single named list, or a list of lists aligned with par_names")
+    }
+  }
+
+  # ---- Validate kernel_args entries for known kernels ----
+  delta_kernels <- c("delta", "delta2kernel", "delta2lr")
+  for (i in seq_along(par_names)) {
+    ka <- kernel_args[[i]]
+    if (is.null(ka)) next
+    if (!is.list(ka)) stop("Each kernel_args entry must be a named list or NULL")
+
+    # q_reset_column is only meaningful for delta-family kernels
+    if (!is.null(ka$q_reset_column) && !(kernels[i] %in% delta_kernels)) {
+      warning(sprintf(
+        "kernel_args$q_reset_column specified for par '%s' but kernel '%s' is not a delta kernel; ignored.",
+        par_names[i], kernels[i]
+      ))
+      kernel_args[[i]]$q_reset_column <- NULL
+    }
+  }
+
 
   trends_out <- list()
   all_trend_pnames <- c()
@@ -336,6 +382,7 @@ make_trend <- function(par_names, cov_names = NULL, kernels, bases = NULL,
     trend$covariate <- unlist(cov_names[i])
     trend$par_input <- unlist(par_input[[i]])
     trend$phase <- phase[i]
+    trend$kernel_args <- kernel_args[[i]]
     if(is.null(ffill_na[i])) {
       if(trend$kernel %in% c('delta', 'delta2kernel', 'delta2lr')) trend$ffill_na <- TRUE else trend$ffill_na <- FALSE
     } else {

--- a/man/make_trend.Rd
+++ b/man/make_trend.Rd
@@ -16,7 +16,8 @@ make_trend(
   at = "lR",
   maps = NULL,
   custom_trend = NULL,
-  ffill_na = NULL
+  ffill_na = NULL,
+  kernel_args = NULL
 )
 }
 \arguments{
@@ -48,6 +49,16 @@ corresponding to the first level of that factor, and fed forward to the other le
 If \code{TRUE}, missing values are forward-filled using the last known non-\code{NA} value after
 applying the kernel. If \code{FALSE}, trials with missing covariates contribute \code{0} instead.
 The default (NULL) is interpreted as \code{TRUE} for delta-rule models and \code{FALSE} otherwise.}
+
+\item{kernel_args}{Optional named list of kernel-specific arguments, aligned with \code{par_names}.
+Can be \code{NULL} (no arguments) or a single named list applied to all parameters.
+Currently supported arguments:
+\describe{
+\item{\code{q_reset_column}}{For delta-family kernels (\code{"delta"}, \code{"delta2kernel"},
+\code{"delta2lr"}) only. Name of a logical or integer column in \code{data} indicating
+trials on which the Q-value should be reset to \code{q0} before the prediction error
+is computed. \code{TRUE}/\code{1} triggers a reset; \code{FALSE}/\code{0} does not.}
+}}
 }
 \value{
 A list containing the trend specifications for each parameter

--- a/src/TrendEngine.cpp
+++ b/src/TrendEngine.cpp
@@ -3,6 +3,69 @@
 using namespace Rcpp;
 
 
+// ============================================================
+// New helper: init_kernel_args_for_slot()
+// Call this during TrendPlan construction, after the slot's
+// kernel_type is known, alongside init_covariate_for_slot() etc.
+// ============================================================
+void init_kernel_args_for_slot(KernelSlotSpec& slot,
+                               const Rcpp::List& tr,       // one trend list entry
+                               const Rcpp::DataFrame& data)
+{
+  // Nothing to do if no kernel_args field in the trend spec
+  if (!tr.containsElementNamed("kernel_args")) {
+    slot.build_kernel_args();
+    return;
+  }
+
+  SEXP ka_sexp = tr["kernel_args"];
+  if (Rf_isNull(ka_sexp)) {
+    slot.build_kernel_args();
+    return;
+  }
+
+  Rcpp::List ka = Rcpp::as<Rcpp::List>(ka_sexp);
+
+  // ---- q_reset_column ----
+  if (ka.containsElementNamed("q_reset_column")) {
+    SEXP col_name_sexp = ka["q_reset_column"];
+    if (!Rf_isNull(col_name_sexp)) {
+      std::string col_name = Rcpp::as<std::string>(col_name_sexp);
+
+      if (!data.containsElementNamed(col_name.c_str())) {
+        Rcpp::stop("kernel_args$q_reset_column: column '%s' not found in data",
+                   col_name.c_str());
+      }
+
+      SEXP col = data[col_name.c_str()];
+
+      // Accept logical or integer columns; coerce to integer for raw-pointer access
+      if (TYPEOF(col) == LGLSXP) {
+        slot.q_reset_col = Rcpp::as<Rcpp::IntegerVector>(col);  // TRUE->1, FALSE->0, NA->NA_INTEGER
+      } else if (TYPEOF(col) == INTSXP) {
+        slot.q_reset_col = Rcpp::IntegerVector(col);
+      } else {
+        Rcpp::stop("kernel_args$q_reset_column: column '%s' must be logical or integer",
+                   col_name.c_str());
+      }
+
+      // Rprintf("q_reset_size=%d\n", (int)slot.q_reset_col.size());
+      // Validate length matches data
+      if (slot.q_reset_col.size() != data.nrows()) {
+        Rcpp::stop("kernel_args$q_reset_column: column '%s' has length %d, expected %d",
+                   col_name.c_str(), (int)slot.q_reset_col.size(), (int)data.nrows());
+      }
+    }
+  }
+
+  // Future kernel_args fields parsed here in the same pattern.
+
+  // Sync raw-pointer view from all populated fields
+  slot.build_kernel_args();
+}
+
+
+
 void TrendOpSpec::make_first_level(const Rcpp::DataFrame& data) {
   using namespace Rcpp;
 
@@ -385,6 +448,7 @@ TrendPlan::TrendPlan(Rcpp::Nullable<Rcpp::List> trend_,
               tr_copy["covariate"] = cov_name;
 
               init_covariate_for_slot(slot, tr_copy, data);
+              init_kernel_args_for_slot(slot, tr_copy, data);
 
               // Attach maps if present on this spec and in data
               if (has_data_covariate_maps) {
@@ -556,6 +620,7 @@ void TrendRuntime::bind_all_ops_to_paramtable(const ParamTable& pt) {
         KernelSlotRuntime k_rt;
         k_rt.spec         = &kspec;
         k_rt.kernel_ptr   = make_kernel(kspec.kernel_type, kspec.custom_fun);
+        k_rt.kernel_ptr->set_kernel_args(kspec.kernel_args);
         k_rt.kernel_par_indices = kernel_indices;
         op_rt.kernels.push_back(std::move(k_rt));
       }

--- a/src/TrendEngine.h
+++ b/src/TrendEngine.h
@@ -46,6 +46,23 @@ struct KernelSlotSpec {
   // Covariate maps specific to this kernel
   bool has_covariate_maps = false;
   std::vector<Rcpp::NumericVector> covariate_map_cols;
+
+  // ---- kernel_args (general extensible mechanism) ----
+  // The IntegerVector members own the R memory; KernelArgs holds raw pointers
+  // into them. Always populate KernelArgs from these after any resize.
+  Rcpp::IntegerVector q_reset_col;   // length n_trials, or length-0 if unused
+  KernelArgs kernel_args;            // raw-pointer view, built in build_kernel_args()
+
+  // Call this after setting q_reset_col (and any future fields) to sync
+  // the raw-pointer view. Must be called before the kernel is constructed.
+  void build_kernel_args() {
+    kernel_args = KernelArgs{};  // zero all fields
+    if (q_reset_col.size() > 0) {
+      kernel_args.q_reset = q_reset_col.begin();
+    }
+    // Future fields: kernel_args.some_other = some_other_col.size() > 0
+    //                                       ? some_other_col.begin() : nullptr;
+  }
 };
 
 // One trend operation spec, built from one element of the R 'trend' list

--- a/src/kernels.h
+++ b/src/kernels.h
@@ -14,6 +14,13 @@ struct KernelParsView {
   std::vector<const double*> cols;  // cols[k][row] = value for param k at trial row
 };
 
+// Struct for optional kernel arguments. Currently only "q-value resetting" is supported.
+struct KernelArgs {
+  const int* q_reset = nullptr;  // raw pointer into an IntegerVector; null = no reset
+  // Future extensible fields go here, e.g.:
+  // const double* some_other_col = nullptr;
+};
+
 // ---- Types ----
 
 enum class KernelType {
@@ -85,6 +92,8 @@ public:
     expand_idx_.clear();
     has_expand_idx_ = false;
   }
+
+  virtual void set_kernel_args(const KernelArgs& /*args*/) {}
 
   bool has_run() const { return has_run_; }
 
@@ -214,9 +223,14 @@ protected:
   double q_ = NA_REAL;             // latest value
   double pe_ = NA_REAL;            // latest PE
   std::vector<double> pes_;        // PE per trial
+  const int* q_reset_ = nullptr;   // <-- ADD: null = no reset
 
 public:
   virtual ~DeltaKernel() {}
+
+  void set_kernel_args(const KernelArgs& args) override {
+    q_reset_ = args.q_reset;
+  }
 
   const std::vector<double>& get_pes() const {
     return pes_;
@@ -572,6 +586,13 @@ struct SimpleDelta : DeltaKernel {
 
              for (int j = 0; j < n_comp - 1; ++j) {
                int r    = comp_idx[j];
+
+               // --- RESET (before PE) ---
+               if (q_reset_ && q_reset_[r]) {
+                 q_ = q0_col[r];
+                 out_[j] = q_;           // overwrite with reset value
+               }
+
                double x = cov_ptr[r];
                // note to future self -- without --ffast-math, x == x also checks for NaN. But --ffast-math breaks that
                if (!ISNAN(x)) {  // do NOT replace with std::isnan or x==x: -ffast-math makes both unreliable               if (!std::isnan(x)) {
@@ -616,6 +637,13 @@ struct Delta2LR : DeltaKernel {
 
              for (int j = 0; j < n_comp - 1; ++j) {
                int r = comp_idx[j];
+
+               // --- RESET (before PE) ---
+               if (q_reset_ && q_reset_[r]) {
+                 q_ = q0_col[r];
+                 out_[j] = q_;           // overwrite with reset value
+               }
+
                double x = covariate(r,0);
                if (!ISNAN(x)) {
                  double alphaPos = alphaPos_col[r];
@@ -640,6 +668,11 @@ struct Delta2Kernel : SequentialKernel {
   double qFast_ = NA_REAL;
   double qSlow_ = NA_REAL;
   double q_     = NA_REAL;
+  const int* q_reset_ = nullptr;   // <-- ADD: null = no reset
+
+  void set_kernel_args(const KernelArgs& args) override {
+    q_reset_ = args.q_reset;
+  }
 
   // [compressed trial][0 = fast PE, 1 = slow PE]
   std::vector<double> pes_fast_;
@@ -674,6 +707,13 @@ struct Delta2Kernel : SequentialKernel {
 
              for (int j = 0; j < n_comp - 1; ++j) {
                int r = comp_idx[j];
+
+               // --- RESET (before PE): both trackers reset to q0 ---
+               if (q_reset_ && q_reset_[r]) {
+                 qFast_ = qSlow_ = q_ = q0_col[r];
+                 out_[j] = q_;           // overwrite with reset value
+               }
+
                double x = covariate(r,0);
                double peFast = NA_REAL;
                double peSlow = NA_REAL;

--- a/tests/testthat/test-kernels.R
+++ b/tests/testthat/test-kernels.R
@@ -7,7 +7,7 @@ make_tiny_design <- function(trend) {
                 model = LNR))
 }
 
-make_minimal_emc <- function(trend, n_trials=5, covariate1=1:5) {
+make_minimal_emc <- function(trend, n_trials=5, covariate1=1:5, ...) {
   ## This *ONLY* creates an EMC object with the covariates. Kernel pars are ignored
   this_design <- make_tiny_design(trend)
   p_vector <- sampled_pars(this_design, doMap = FALSE)  # no kernel pars
@@ -16,7 +16,14 @@ make_minimal_emc <- function(trend, n_trials=5, covariate1=1:5) {
   #   p_vector[names(kernel_pars)] <- kernel_pars
   # }
 
+  opts <- list(...)
+
   dat <- make_data(p_vector, this_design, n_trials = n_trials, covariates = data.frame(covariate1 = covariate1))
+
+  for(nm in names(opts)) {
+    dat[,nm] <- opts[[nm]]
+  }
+
   emc <- make_emc(dat, this_design, type='single')
   return(emc)
 }
@@ -231,6 +238,25 @@ test_that("delta2kernel_Rcpp", {
   expect_snapshot(matrix(apply_kernel(kernel_pars, emc, mode="Rcpp")))
 })
 
+
+## test resetting
+trend_delta <- make_trend(par_names = "m",
+                          cov_names = 'covariate1',
+                          kernels = 'delta', base='add',
+                          kernel_args=list(q_reset_column='do_reset'))
+kernel_pars <- c('m.q0'=0, 'm.alpha'=0.2)
+covariate1 <- c(1, 1, 1, 1, 1)
+emc <- make_minimal_emc(trend_delta, covariate1 = covariate1, do_reset=c(F,F,T,F,F))
+expected_output <- matrix(c(0, 0.2, 0, 0.2, 0.36)) # manually computed for this specific covariate + parameter vector
+# all.equal(matrix(apply_kernel(kernel_pars, emc, mode="R")), matrix(expected_output))
+# all.equal(matrix(apply_kernel(kernel_pars, emc, mode="Rcpp")), matrix(expected_output))
+all.equal(matrix(apply_kernel(kernel_pars, emc, mode="Rcpp_oo")), matrix(expected_output))
+# test_that("delta_R", {
+#   expect_snapshot(matrix(apply_kernel(kernel_pars, emc, mode="R")))
+# })
+test_that("delta_Rcpp", {
+  expect_snapshot(matrix(apply_kernel(kernel_pars, emc, mode="Rcpp_oo")))
+})
 
 #
 # # Custom kernel -- only C -------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds the ability to reset the Q-value of delta-family kernels (`delta`, `delta2lr`, `delta2kernel`) at user-specified trials. This is useful for paradigms where the learned value should be re-initialised mid-sequence — for example, at the start of a new block or after a context switch.

## Usage

A column in `data` (logical or integer) marks the trials on which a reset should occur. Pass its name via the new `kernel_args` argument to `make_trend()`:

```r
trend_delta <- make_trend(
  par_names   = "m",
  cov_names   = "covariate1",
  kernels     = "delta",
  base        = "add",
  kernel_args = list(q_reset_column = "do_reset")
)
```

On any trial where `data$do_reset` is `TRUE` (or `1`), the Q-value is reset to the current trial's `q0` parameter value *before* the prediction error is computed.

## Changes

### R
- `make_trend()` gains a `kernel_args` argument — a named list (or list of named lists) of kernel-specific options, normalised per-kernel in the same way as `par_input`
- Smart normalization: a flat `list(q_reset_column = "x")` is automatically detected and wrapped, so single-kernel calls don't require an extra `list()` layer
- A warning is raised if `q_reset_column` is specified for a non-delta kernel

### C++

**`kernels.h`**
- New `KernelArgs` struct: a lightweight raw-pointer view of kernel arguments, extensible for future use
- `BaseKernel` gains a no-op virtual `set_kernel_args()` so non-delta kernels require no changes
- `DeltaKernel` stores a `const int* q_reset_` member and overrides `set_kernel_args()`; inherited by `SimpleDelta` and `Delta2LR`
- `Delta2Kernel` independently stores `q_reset_` and overrides `set_kernel_args()`
- All three `run()` loops apply the reset before the PE computation, and overwrite `out_[j]` (and `q_fast_[j]`/`q_slow_[j]` for `Delta2Kernel`) to keep all output streams consistent

**`TrendEngine.h`**
- `KernelSlotSpec` gains an `Rcpp::IntegerVector q_reset_col` (memory owner) and a `KernelArgs kernel_args` (raw-pointer view), with a `build_kernel_args()` method to sync the two

**`TrendEngine.cpp`**
- New helper `init_kernel_args_for_slot()` parses `kernel_args` from the trend spec, looks up and validates the reset column in `data`, and calls `build_kernel_args()`
- `bind_trend_op_to_paramtable()` calls `set_kernel_args()` on each kernel after construction

## Notes

- **Reset timing**: the reset fires *before* the PE is computed on the flagged trial, so the Q-value entering that trial is `q0`
- **Reset value**: always the current trial's `q0` parameter, consistent with how the sequence is initialised
- **Performance**: the hot loop cost is a single null-pointer check (`if (q_reset_ && q_reset_[r])`), which is free when no reset column is provided and branch-predictor friendly when resets are rare
- **Extensibility**: `KernelArgs` and `init_kernel_args_for_slot()` are designed as a general mechanism; future kernel-specific options follow the same pattern with minimal boilerplate