### PR TITLE
workaround for zero drift bug in WienR::rWDM

### DIFF
--- a/R/model_DDM.R
+++ b/R/model_DDM.R
@@ -41,7 +41,8 @@ rDDM <- function(R,pars,ok=rep(TRUE,length(R)), precision=5e-3)
 {
   pars <- pars[ok,,drop=FALSE]
   R <- R[ok]
-  pars <- as.matrix(pars);
+  pars <- as.matrix(pars)
+  zero_drift_check_needed <- utils::packageVersion("WienR") < "0.3-17"
   # DDM gets unhappy with large trial numbers so split them into separate lists
   split_idx <- rep(1:ceiling(nrow(pars)/5e3), each = 5e3)
   split_idx <- split_idx[1:nrow(pars)]
@@ -53,9 +54,19 @@ rDDM <- function(R,pars,ok=rep(TRUE,length(R)), precision=5e-3)
     for(id in unique(idx)){
       is_id <- which(idx == id)
       cur_pars <- pars_tmp[is_id[1],]
-      tmp <- suppress_output(rWDM(N = length(is_id), a = cur_pars["a"]/cur_pars[ "s"], v = cur_pars["v"]/cur_pars[ "s"], t0 = cur_pars["t0"],
-                                  w = cur_pars["Z"], sw = cur_pars["SZ"], sv = cur_pars["sv"]/cur_pars[ "s"],
-                                  st0 = cur_pars["st0"], precision = precision, method="p-ars"))
+      cur_pars_drift <- cur_pars["v"]/cur_pars[ "s"]
+      # old versions of WienR have bug in generating responses (lower vs upper boundary)
+      # when drift rate is exactly zero
+      if (zero_drift_check_needed && cur_pars_drift == 0) {
+        cur_pars_drift <- 1e-10
+      }
+      tmp <- suppress_output(rWDM(
+        N = length(is_id),
+        a = cur_pars["a"]/cur_pars[ "s"], v = cur_pars_drift, w = cur_pars["Z"],
+        t0 = cur_pars["t0"],
+        sw = cur_pars["SZ"], sv = cur_pars["sv"]/cur_pars[ "s"], st0 = cur_pars["st0"],
+        precision = precision, method="p-ars"
+      ))
       tmp <- data.frame(R = tmp$response, rt = tmp$q)
       out[is_id,] <- tmp
     }

--- a/tests/testthat/_snaps/new_models.md
+++ b/tests/testthat/_snaps/new_models.md
@@ -19,7 +19,7 @@
       
       $subj_ll
              [,1]
-      1 -149.5918
+      1 -126.1569
       
       $idx
       [1] 1
@@ -33,14 +33,14 @@
          trials subjects     S     R        rt
       1       1        1  left right 0.5699457
       2       2        1  left right 1.0712502
-      3       3        1  left right 0.9057347
+      3       3        1  left  left        NA
       4       4        1  left right 0.8566880
-      5       5        1  left right 0.6253342
+      5       5        1  left  left        NA
       6       6        1  left right 1.0906341
       7       7        1  left right 0.5305895
       8       8        1  left right 0.5611776
       9       9        1  left right 0.5721548
-      10     10        1  left right 0.7099338
+      10     10        1  left  left        NA
       11     11        1 right right 0.5117904
       12     12        1 right right 0.5066511
       13     13        1 right right 0.7898381


### PR DESCRIPTION
I recently encountered a bug in `WienR::rWDM`: When the drift rate is _exactly_ zero, the simulated responses are exclusively at the lower boundary. The expected output is a 50/50 split between lower- and upper-boundary responses. This issue propagates to `EMC2::make_data` when using the DDM.

``` r
# install older version of WienR
remotes::install_version("WienR", "0.3-15", force = TRUE, quiet = TRUE)
library(WienR)

# set up for sims
sim_resp_prop_WienR <- function(drift, N = 1e5) {
  sim_resp <- WienR::rWDM(N = N, a = 1, v = drift, w = 0.5)$response
  return(round(table(unname(sim_resp))/N, digits = 3))
}
RNGkind("L'Ecuyer-CMRG")
set.seed(123)

# correct output when drift is *practically* zero:
# circa 50/50 split between lower- and upper-boundary responses
sim_resp_prop_WienR(drift = -1e-10)
#> 
#> lower upper 
#>   0.5   0.5
sim_resp_prop_WienR(drift = 1e-10)
#> 
#> lower upper 
#> 0.498 0.502

# incorrect output when drift is *exactly* zero:
# exclusively lower-boundary responses
sim_resp_prop_WienR(drift = 0)
#> 
#> lower 
#>     1

# bug propagates to EMC2::make_data when using DDM
remotes::install_github(
  "ampl-psych/EMC2", ref = "dev", dependencies = FALSE, force = TRUE, quiet = TRUE
)
library(EMC2)

minimal_DDM_design <- EMC2::design(
  formula = list(v ~ 1, a ~ 1, t0 ~ 1, s ~ 1, Z ~ 1, SZ ~ 1, sv ~ 1, st0 ~ 1),
  factors = list(S = c("left", "right"), subjects = 1),
  Rlevels = c("left", "right"),
  model = EMC2::DDM,
  constants = c(
    a = log(1), t0 = log(0.2), s = log(1), Z = qnorm(0.5),
    SZ = qnorm(0), sv = log(0), st0 = log(0)
  ),
  report_p_vector = FALSE
)
sim_resp_prop_EMC2 <- function(drift, N = 1e5) {
  sim_resp <- EMC2::make_data(
    parameters = c(v = drift),
    design = minimal_DDM_design,
    n_trials = N/2
  )$R
  return(round(table(unname(sim_resp))/N, digits = 3))
}
sim_resp_prop_EMC2(drift = 1e-10)
#> 
#>  left right 
#>   0.5   0.5
sim_resp_prop_EMC2(drift = 0)
#> 
#>  left right 
#>     0     1
```

<sup>Created on 2026-07-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

@andrewheathcote contacted `WienR` maintainer Raphael Hartmann, who then [fixed the bug](https://github.com/RaphaelHartmann/WienR/commit/6b26edf3b29fd365e8dbe601e8eb2cb0004662b3) and released a new version to CRAN (version 0.3-17, dated July 7th 2026).

``` r
# install newest version of WienR
remotes::install_version("WienR", "0.3-17", force = TRUE, quiet = TRUE)
library(WienR)

# set up for sims
sim_resp_prop_WienR <- function(drift, N = 1e5) {
  sim_resp <- WienR::rWDM(N = N, a = 1, v = drift, w = 0.5)$response
  return(round(table(unname(sim_resp))/N, digits = 3))
}
RNGkind("L'Ecuyer-CMRG")
set.seed(123)
sim_resp_prop_WienR(drift = 0)
#> 
#> lower upper 
#>   0.5   0.5
```

<sup>Created on 2026-07-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
 
This PR adds a little workaround to `rDDM`: It checks what version of `WienR` is installed, and if necessary (i.e., if not the most recent version), any drift rate of exactly zero is adjusted to a nominal value of 1e-10.