### PR TITLE
Improve get_pars_c_wrapper

### DIFF
--- a/R/new_map.R
+++ b/R/new_map.R
@@ -343,28 +343,53 @@ par_data_map <- function(par_mcmc, design, n_trials = NULL, data = NULL,
   n_mcmc <- dim(par_mcmc)[3]
   n_pars <- dim(par_mcmc)[1]
   n_subs <- ncol(par_mcmc)
-  for(i in 1:n_mcmc){
-    parameters <- t(matrix(par_mcmc[,,i, drop = FALSE], nrow = n_pars, ncol = n_subs))
+
+  # SM: Don't loop over mcmc particles (do this loop in C); loop over subjects here
+  dadm_list <- dm_list(data)
+  row_ids <- split(seq_len(nrow(data)), data$subjects)
+
+  for(i in 1:n_subs) {
+    # par_mcmc is n_pars x n_subs x n_mcmc
+    parameters <- t(matrix(par_mcmc[,i,,drop=FALSE], nrow=n_pars, ncol=n_mcmc))
     colnames(parameters) <- dimnames(par_mcmc)[[1]]
-    if(nrow(parameters) == length(unique(data$subjects))){
-      design$Ffactors$subjects <- unique(data$subjects)
+    pars <- get_pars_singlesub_oo(parameters, dadm_list[[i]], model(), return_all_pars=TRUE)
+
+    if (!add_recalculated) {
+      base_names <- intersect(names(model()$p_types), dimnames(pars)[[3]])
+      pars <- pars[,, base_names, drop = FALSE]
     }
 
-    rownames(parameters) <- design$Ffactors$subjects
-    pars <- get_pars_matrix_oo(parameters, data, model(), return_all_pars=TRUE)
-    if(!add_recalculated){
-      base_names <- intersect(names(model()$p_types), colnames(pars))
-      pars <- pars[, base_names, drop = FALSE]
-      attr(pars, "ok") <- NULL
-    }
-    if(i == 1){
-      out <- array(NA, dim = c(nrow(pars), n_mcmc, ncol(pars)),
-                   dimnames = list(NULL, NULL, colnames(pars)))
-    }
-    out[,i,] <- pars
+    if(i == 1) {
+      out <- array(NA_real_, dim = c(nrow(data), n_mcmc, dim(pars)[3]),
+                   dimnames = list(NULL, NULL, dimnames(pars)[[3]]))
+      }
+    out[row_ids[[i]],,] <- pars
   }
   return(list(data = data, pars = out))
 }
+
+#   for(i in 1:n_mcmc){
+#     parameters <- t(matrix(par_mcmc[,,i, drop = FALSE], nrow = n_pars, ncol = n_subs))
+#     colnames(parameters) <- dimnames(par_mcmc)[[1]]
+#     if(nrow(parameters) == length(unique(data$subjects))){
+#       design$Ffactors$subjects <- unique(data$subjects)
+#     }
+#
+#     rownames(parameters) <- design$Ffactors$subjects
+#     pars <- get_pars_matrix_oo(parameters, data, model(), return_all_pars=TRUE)
+#     if(!add_recalculated){
+#       base_names <- intersect(names(model()$p_types), colnames(pars))
+#       pars <- pars[, base_names, drop = FALSE]
+#       attr(pars, "ok") <- NULL
+#     }
+#     if(i == 1){
+#       out <- array(NA, dim = c(nrow(pars), n_mcmc, ncol(pars)),
+#                    dimnames = list(NULL, NULL, colnames(pars)))
+#     }
+#     out[,i,] <- pars
+#   }
+#   return(list(data = data, pars = out))
+# }
 
 group_mapping <- function(samples, selection) {
   if(ncol(samples) < 2) stop("Please use type = 'single' for designs with 1 subject")

--- a/R/new_map.R
+++ b/R/new_map.R
@@ -347,24 +347,30 @@ par_data_map <- function(par_mcmc, design, n_trials = NULL, data = NULL,
   # SM: Don't loop over mcmc particles (do this loop in C); loop over subjects here
   dadm_list <- dm_list(data)
   row_ids <- split(seq_len(nrow(data)), data$subjects)
+  out <- NULL
 
-  for(i in 1:n_subs) {
+  for (i in seq_len(n_subs)) {
     # par_mcmc is n_pars x n_subs x n_mcmc
     parameters <- t(matrix(par_mcmc[,i,,drop=FALSE], nrow=n_pars, ncol=n_mcmc))
     colnames(parameters) <- dimnames(par_mcmc)[[1]]
-    pars <- get_pars_singlesub_oo(parameters, dadm_list[[i]], model(), return_all_pars=TRUE)
+    pars_list <- get_pars_singlesub_oo(parameters, dadm_list[[i]], model(), return_all_pars=TRUE)
 
-    if (!add_recalculated) {
-      base_names <- intersect(names(model()$p_types), dimnames(pars)[[3]])
-      pars <- pars[,, base_names, drop = FALSE]
+    # not yet sure how many columns will be returned - so get from first subject
+    if(is.null(out)) {
+      par_names <- colnames(pars_list[[1]])
+      out <- array(NA_real_, dim = c(nrow(data), n_mcmc, length(par_names)),
+                   dimnames = list(NULL, NULL, par_names))
     }
 
-    if(i == 1) {
-      out <- array(NA_real_, dim = c(nrow(data), n_mcmc, dim(pars)[3]),
-                   dimnames = list(NULL, NULL, dimnames(pars)[[3]]))
-      }
-    out[row_ids[[i]],,] <- pars
+    # fill
+    row_idx <- row_ids[[i]]
+    for (k in seq_len(n_mcmc)) out[row_idx, k, ] <- pars_list[[k]]
   }
+  if (!add_recalculated) {
+    base_names <- intersect(names(model()$p_types), dimnames(out)[[3]])
+    out <- out[,, base_names, drop = FALSE]
+  }
+
   return(list(data = data, pars = out))
 }
 

--- a/R/oo_map.R
+++ b/R/oo_map.R
@@ -234,20 +234,10 @@ get_pars_singlesub_oo <- function(p, dadm, model,
   ord <- c(intersect(base_names, colnames(first_pars)), setdiff(colnames(first_pars), base_names))
   col_idx <- if (identical(ord, colnames(first_pars))) NULL else match(ord, colnames(first_pars))
   # Ttransform and reordering per element
-  pars_list <- lapply(pars_list, function(pars) {
+  lapply(pars_list, function(pars) {
     pars <- model_list$Ttransform(pars, dadm)
     .oo_reorder_public_pars(pars, model_list, col_idx)
   })
-
-  # Return n_data_rows x n_particles x n_pars array
-  n_rows <- nrow(pars_list[[1]])
-  n_pars <- ncol(pars_list[[1]])
-  par_names <- colnames(pars_list[[1]])
-
-  out <- array(NA_real_, dim = c(n_rows, n_particles, n_pars),
-               dimnames = list(NULL, NULL, par_names))
-  for (k in seq_len(n_particles)) out[, k, ] <- pars_list[[k]]
-  out
 }
 
 

--- a/R/oo_map.R
+++ b/R/oo_map.R
@@ -47,15 +47,16 @@
   )
 }
 
-.oo_reorder_public_pars <- function(pars, model_list) {
-  base_names <- names(model_list$p_types)
-  ord <- c(intersect(base_names, colnames(pars)), setdiff(colnames(pars), base_names))
-  if (identical(ord, colnames(pars))) {
-    return(pars)
+.oo_reorder_public_pars <- function(pars, model_list, col_idx = NULL) {
+  if (is.null(col_idx)) {
+    base_names <- names(model_list$p_types)
+    ord <- c(intersect(base_names, colnames(pars)), setdiff(colnames(pars), base_names))
+    if (identical(ord, colnames(pars))) return(pars)
+    col_idx <- match(ord, colnames(pars))
   }
 
   ok <- attr(pars, "ok")
-  pars <- pars[, ord, drop = FALSE]
+  pars <- pars[, col_idx, drop = FALSE]
   attr(pars, "ok") <- ok
   pars
 }
@@ -111,6 +112,7 @@
   p
 }
 
+## used for parameter matrices with multiple particpants (ie one row in p per participant)
 get_pars_oo <- function(p, dadm, model,
                         pretransformed = FALSE,
                         constants_included = FALSE,
@@ -142,7 +144,7 @@ get_pars_oo <- function(p, dadm, model,
       return_kernel_matrix = return_kernel_matrix,
       return_all_pars = return_all_pars,
       kernel_output_codes = kernel_output_codes
-    )
+    )[[1]]  # now returns a list
   }
 
   if (!("subjects" %in% names(dadm)) || nrow(particle_matrix) == 1L) {
@@ -188,6 +190,64 @@ get_pars_matrix_oo <- function(p_vector, dadm, model, return_all_pars=FALSE) {
   model_list <- .oo_model_list(model)
   pars <- get_pars_oo(p_vector, dadm, model_list, return_all_pars=return_all_pars)
   pars <- model_list$Ttransform(pars, dadm)
-  pars <- add_bound(pars, model_list$bound, dadm$lR)
+  # pars <- add_bound(pars, model_list$bound, dadm$lR) # now handled in get_pars_wrapper
   .oo_reorder_public_pars(pars, model_list)
 }
+
+get_pars_singlesub_oo <- function(p, dadm, model,
+                                  pretransformed = FALSE,
+                                  constants_included = FALSE,
+                                  return_kernel_matrix = FALSE,
+                                  return_all_pars = FALSE,
+                                  kernel_output_codes = 1L) {
+  model_list <- .oo_model_list(model)
+  particle_matrix <- .oo_particle_matrix(p, dadm, keep_all_columns = constants_included)
+  constants <- attr(dadm, "constants")
+  if (constants_included || is.null(constants)) {
+    constants <- NA
+  }
+  pretransforms <- if (pretransformed) {
+    .oo_identity_transform(colnames(particle_matrix))
+  } else {
+    model_list$pre_transform
+  }
+
+  designs <- get_designs_expanded(dadm, model)
+
+  pars_list <- get_pars_c_wrapper(particle_matrix = particle_matrix,
+                             data = dadm,
+                             constants = constants,
+                             designs = designs,
+                             bounds = model_list$bound,
+                             transforms = model_list$transform,
+                             pretransforms = pretransforms,
+                             trend = model_list$trend,
+                             return_kernel_matrix = return_kernel_matrix,
+                             return_all_pars = return_all_pars,
+                             kernel_output_codes = kernel_output_codes)
+  # pars_list[[k]] is n_data_rows x n_pars for particle k
+  # Apply Ttransform and add_bound per particle, then stack into array
+  n_particles <- length(pars_list)
+  # compute order of returning once
+  first_pars <- model_list$Ttransform(pars_list[[1]], dadm)
+  base_names <- names(model_list$p_types)
+  ord <- c(intersect(base_names, colnames(first_pars)), setdiff(colnames(first_pars), base_names))
+  col_idx <- if (identical(ord, colnames(first_pars))) NULL else match(ord, colnames(first_pars))
+  # Ttransform and reordering per element
+  pars_list <- lapply(pars_list, function(pars) {
+    pars <- model_list$Ttransform(pars, dadm)
+    .oo_reorder_public_pars(pars, model_list, col_idx)
+  })
+
+  # Return n_data_rows x n_particles x n_pars array
+  n_rows <- nrow(pars_list[[1]])
+  n_pars <- ncol(pars_list[[1]])
+  par_names <- colnames(pars_list[[1]])
+
+  out <- array(NA_real_, dim = c(n_rows, n_particles, n_pars),
+               dimnames = list(NULL, NULL, par_names))
+  for (k in seq_len(n_particles)) out[, k, ] <- pars_list[[k]]
+  out
+}
+
+

--- a/R/trend.R
+++ b/R/trend.R
@@ -1722,7 +1722,7 @@ make_data_unconditional <- function(data, pars, design, model,
         trend                = model_list$trend,
         return_kernel_matrix = FALSE,
         return_all_pars      = TRUE
-      )
+      )[[1]]  # returns a list per particle
 
       if (tmp_return_trialwise && !is.null(model_list$trend)) {
         covariates <- get_pars_c_wrapper(
@@ -1737,7 +1737,7 @@ make_data_unconditional <- function(data, pars, design, model,
           return_kernel_matrix = TRUE,
           kernel_output_codes  = kernel_output_codes,
           return_all_pars      = TRUE
-        )
+        )[[1]]
         attr(pm, "trialwise_parameters") <- covariates
       }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -504,7 +504,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // get_pars_c_wrapper
-NumericMatrix get_pars_c_wrapper(NumericMatrix particle_matrix, DataFrame data, NumericVector constants, List designs, List bounds, List transforms, List pretransforms, Rcpp::Nullable<Rcpp::List> trend, bool return_kernel_matrix, bool return_all_pars, IntegerVector kernel_output_codes);
+List get_pars_c_wrapper(NumericMatrix particle_matrix, DataFrame data, NumericVector constants, List designs, List bounds, List transforms, List pretransforms, Rcpp::Nullable<Rcpp::List> trend, bool return_kernel_matrix, bool return_all_pars, IntegerVector kernel_output_codes);
 RcppExport SEXP _EMC2_get_pars_c_wrapper(SEXP particle_matrixSEXP, SEXP dataSEXP, SEXP constantsSEXP, SEXP designsSEXP, SEXP boundsSEXP, SEXP transformsSEXP, SEXP pretransformsSEXP, SEXP trendSEXP, SEXP return_kernel_matrixSEXP, SEXP return_all_parsSEXP, SEXP kernel_output_codesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/particle_ll.cpp
+++ b/src/particle_ll.cpp
@@ -672,43 +672,69 @@ NumericVector calc_ll(NumericMatrix particle_matrix, DataFrame data, NumericVect
 
 
 // [[Rcpp::export]]
-NumericMatrix get_pars_c_wrapper(NumericMatrix particle_matrix,
-                                 DataFrame data,
-                                 NumericVector constants,
-                                 List designs,
-                                 List bounds,
-                                 List transforms,
-                                 List pretransforms,
-                                 Rcpp::Nullable<Rcpp::List> trend = R_NilValue,
-                                 bool return_kernel_matrix = false,
-                                 bool return_all_pars = false,
-                                 IntegerVector kernel_output_codes = 1)
+List get_pars_c_wrapper(NumericMatrix particle_matrix,
+                        DataFrame data,
+                        NumericVector constants,
+                        List designs,
+                        List bounds,
+                        List transforms,
+                        List pretransforms,
+                        Rcpp::Nullable<Rcpp::List> trend = R_NilValue,
+                        bool return_kernel_matrix = false,
+                        bool return_all_pars = false,
+                        IntegerVector kernel_output_codes = 1)
 {
   if (Rf_isNull(colnames(particle_matrix))) {
     stop("p_matrix must have column names for pretransforms/transform specs");
   }
+  const int n_trials    = data.nrow();
+  const int n_particles = particle_matrix.nrow();
+  const bool has_lR     = (sum(contains(data.names(), "lR")) == 1);
+  const int n_lR        = has_lR ? unique(IntegerVector(data["lR"])).length() : 1;
 
   // Shared setup
   PipelineContext ctx = make_pipeline_context(particle_matrix, data, constants,
                                               designs, transforms, pretransforms, trend);
   TrendRuntime* trend_runtime_ptr = ctx.trend_runtime ? ctx.trend_runtime.get() : nullptr;
 
-  // Pipeline cache
-  PipelineCache cache = make_pipeline_cache(ctx.param_table, designs, ctx.transform_specs, trend_runtime_ptr);
+  // Pipeline cache (built once, reused across particles)
+  PipelineCache cache = make_pipeline_cache(ctx.param_table, designs,
+                                            ctx.transform_specs, trend_runtime_ptr);
 
   // kernel_output_codes: IntegerVector -> std::vector<int>
   std::vector<int> kernel_codes(kernel_output_codes.begin(), kernel_output_codes.end());
 
-  // Run pipeline (single particle — no loop needed)
-  run_pars_pipeline(ctx.param_table, designs, trend_runtime_ptr, cache);
+  NumericMatrix   minmax   = bounds["minmax"];
+  CharacterVector mm_names = colnames(minmax);
+  std::vector<BoundSpec> bound_specs = make_bound_specs_pt(minmax, mm_names, ctx.param_table, bounds);
+  std::vector<int> is_ok(n_trials, 1);
 
-  // Extract and return
-  if (return_kernel_matrix) {
-    return get_covariate_matrix(ctx.param_table, trend_runtime_ptr, kernel_codes);
-  } else if (return_all_pars) {
-    return get_all_pars(ctx.param_table);
-  } else {
-    return get_pars_matrix(ctx.param_table, ctx.keep_names);
+  List result(n_particles);
+
+  for (int i = 0; i < n_particles; ++i) {
+    // Update param_table for this particle (skip refill on first particle)
+    if (i > 0) ctx.param_table.fill_from_particle_row(ctx.particle_matrix, i, ctx.pm_col_to_base_idx);
+    run_pars_pipeline(ctx.param_table, designs, trend_runtime_ptr, cache);
+
+    std::fill(is_ok.begin(), is_ok.end(), 1);
+    c_do_bound_pt(ctx.param_table, bound_specs, is_ok);
+    if(n_lR > 1) lr_all(is_ok, n_lR);
+
+    // Convert is_ok to LogicalVector for the attribute
+    LogicalVector ok_attr(is_ok.begin(), is_ok.end());
+    // Extract and store
+    NumericMatrix mat;
+    if (return_kernel_matrix) {
+      mat = get_covariate_matrix(ctx.param_table, trend_runtime_ptr, kernel_codes);
+    } else if (return_all_pars) {
+      mat = get_all_pars(ctx.param_table);
+    } else {
+      mat = get_pars_matrix(ctx.param_table, ctx.keep_names);
+    }
+
+    mat.attr("ok") = ok_attr;
+    result[i] = mat;
   }
-}
 
+  return result;
+}


### PR DESCRIPTION
`get_pars_c_wrapper` now returns a list of length n_particles; each has a matrix with 'ok' as an attribute. Substantially improves performance of functions using it - e.g., `credint(..., map=TRUE)` is roughly 10x as fast.