### PR TITLE
Fix compilation failures

### DIFF
--- a/src/TrendEngine.cpp
+++ b/src/TrendEngine.cpp
@@ -215,7 +215,7 @@ static void build_covariate_coding(BaseSpec& bs,
     Rf_error("BaseSpec '%s': 'coding' specified but data has no 'covariate_coding' attribute",
              bs.target_parameter.c_str());
 
-  Rcpp::List coding_spec(b_lst["coding"]);
+  Rcpp::List coding_spec = b_lst["coding"];
   Rcpp::CharacterVector coding_names = coding_spec.names();
   if (coding_names.size() != coding_spec.size())
     Rf_error("BaseSpec '%s': 'coding' list must be named", bs.target_parameter.c_str());

--- a/src/particle_ll.cpp
+++ b/src/particle_ll.cpp
@@ -786,7 +786,7 @@ List get_pars_c_wrapper(NumericMatrix particle_matrix,
   const int n_trials    = data.nrow();
   const int n_particles = particle_matrix.nrow();
   const bool has_lR     = (sum(contains(data.names(), "lR")) == 1);
-  const int n_lR        = has_lR ? unique(IntegerVector(data["lR"])).length() : 1;
+  const int n_lR = has_lR ? unique(Rcpp::as<IntegerVector>(data["lR"])).length() : 1;
 
   // Shared setup
   PipelineContext ctx = make_pipeline_context(particle_matrix, data, constants,


### PR DESCRIPTION
When attempting to install `dev` on my HPC cluster (GCC 8.5.0; R 4.2.2; Rcpp version 1.1.2), I encountered some compilation failures. Claude figured out these were due to two lines in `TrendEngine.cpp` and `particle_ll.cpp`, and explained the problem as follows:

Fixes a compilation failure on some Rcpp/compiler combinations, where direct-initializing an `Rcpp::Vector`-family container (`List`, `IntegerVector`, etc.) from a proxy expression (`list["name"]`, `dataframe["col"]`) causes an ambiguous overload resolution error.

`List::NameProxy` and `DataFrame`'s column-access proxy support several implicit conversions (to `SEXP`, `std::string`, `const char*`, `int`, `Dimension`, an initializer_list, etc.). When such a proxy is passed to a container constructor using direct-initialization (parentheses), e.g. `Rcpp::List coding_spec(b_lst["coding"])`, the compiler must choose among several equally-viable constructor overloads, since more than one accepts an implicit conversion from the proxy type. This is ambiguous and fails to compile — though only on certain Rcpp/compiler version combinations, which is presumably why it went unnoticed until now.