### PR TITLE
predict() on fits from older EMC2 versions: refresh stale model closures, preserve rows

### DIFF
--- a/R/design.R
+++ b/R/design.R
@@ -197,6 +197,13 @@ design <- function(formula = NULL,factors = NULL,Rlevels = NULL,model,data=NULL,
   formula <- prepared_design$formula
   constants <- prepared_design$constants
 
+  # The DDM likelihood maps the first response level to the lower boundary and
+  # every other level to the upper one, so a third level would be fitted as if
+  # it were the second: refuse rather than silently mis-fit.
+  if (identical(model_type(model), "DDM") && !is.null(Rlevels) && length(Rlevels) != 2) {
+    stop("The DDM requires exactly two response levels; R has ", length(Rlevels),
+         " (", paste(Rlevels, collapse = ", "), "). Recode R (e.g. as correct/error) or drop unused levels.")
+  }
   design <- list(Flist=formula,Ffactors=factors,Rlevels=Rlevels,
                  Clist=contrasts,matchfun=matchfun,constants=constants,
                  Fcovariates=covariates,Ffunctions=functions,model=model,
@@ -1302,6 +1309,89 @@ dm_list <- function(dadm)
   return(dl)
 }
 
+# design() freezes model() into a closure that is serialised with the fit, so a
+# stored emc carries the model *functions* (rfun, dfun, Ttransform, ...) as they
+# were at fit time. Fits made before 058ce1a9 (May 2025) have rfun(lR, pars)
+# whereas make_data() now calls rfun(data, pars): predict() on such an object
+# fails inside rfun. refresh_model() rebuilds the closure from the live
+# constructor, keeping the fit-time transform / pre_transform / bound.
+model_is_stale <- function(model) {
+  ml <- tryCatch(if (is.function(model)) model() else model, error = function(e) NULL)
+  if (!is.list(ml) || !is.function(ml$rfun)) return(FALSE)
+  # The pre-May-2025 signature was rfun(lR, pars); fMRI models legitimately use rfun(pars)
+  identical(names(formals(ml$rfun))[1], "lR")
+}
+
+# Constructors that can be called without arguments, keyed by the c_name/type
+# their model list carries. Custom (user-supplied) models are not refreshable.
+find_model_constructor <- function(old) {
+  ns <- asNamespace("EMC2")
+  candidates <- c("LBA", "RDM", "LNR", "DDM", "DDMGNG", "CDM", "SDM", "HSDM", "PSDM",
+                  "PHSDM", "SSexG", "SShybrid", "SSEXG", "SSRDEX")
+  candidates <- candidates[vapply(candidates, exists, logical(1), envir = ns, mode = "function", inherits = FALSE)]
+  hits <- list()
+  for (nm in candidates) {
+    ctor <- get(nm, envir = ns)
+    ml <- tryCatch(ctor(), error = function(e) NULL)
+    if (is.null(ml)) next
+    same_type <- identical(ml$type, old$type)
+    same_name <- is.null(old$c_name) || identical(ml$c_name, old$c_name)
+    if (same_type && same_name) hits[[nm]] <- ctor
+  }
+  if (length(hits) == 1) return(hits[[1]])
+  if (length(hits) > 1 && !is.null(old$c_name) && old$c_name %in% names(hits)) return(hits[[old$c_name]])
+  NULL
+}
+
+refresh_model <- function(old_model, p_vector = NULL, force = FALSE) {
+  old <- if (is.function(old_model)) old_model() else old_model
+  if (!force && !model_is_stale(old)) return(old_model)
+  ctor <- find_model_constructor(old)
+  if (is.null(ctor)) {
+    stop("The model stored with this object (", if (is.null(old$c_name)) old$type else old$c_name,
+         ") predates the current rfun(data, pars) interface and no matching built-in model was found ",
+         "to refresh it from; custom models must be refreshed by re-running design() with the current model.")
+  }
+  new <- ctor()
+  if (!all(names(old$p_types) %in% names(new$p_types))) {
+    stop("The current ", new$c_name, " model no longer has parameter(s) ",
+         paste(setdiff(names(old$p_types), names(new$p_types)), collapse = ", "))
+  }
+  # Fit-time settings win over the constructor defaults, as they did in design()
+  new$transform <- fill_transform(old$transform, ctor)
+  new$bound <- if (is.list(old$bound) && identical(names(old$bound)[1], "minmax")) {
+    fill_bound(old$bound, ctor)
+  } else fill_bound(NULL, ctor)
+  if (!is.null(old$pre_transform)) {
+    new$pre_transform <- if (is.null(p_vector)) old$pre_transform else
+      fill_transform(old$pre_transform, model = ctor, p_vector = p_vector, is_pre = TRUE)
+  } else if (!is.null(p_vector)) {
+    new$pre_transform <- fill_transform(NULL, model = ctor, p_vector = p_vector, is_pre = TRUE)
+  }
+  # Any non-function extras the fit stored (e.g. trend settings) are kept
+  for (f in setdiff(names(old), names(new))) if (!is.function(old[[f]])) new[[f]] <- old[[f]]
+  model_list <- new
+  function() model_list
+}
+
+emc_has_stale_model <- function(emc) {
+  dl <- attr(emc, "design_list")
+  if (is.null(dl)) dl <- tryCatch(attr(get_prior(emc), "design"), error = function(e) NULL)
+  if (is.null(dl)) return(FALSE)
+  any(vapply(dl, function(d) is.function(d$model) && model_is_stale(d$model), logical(1)))
+}
+
+# Refresh stale model closures of a design list (in memory; see refresh_model)
+refresh_design_models <- function(design_list) {
+  for (i in seq_along(design_list)) {
+    m <- design_list[[i]]$model
+    if (is.function(m) && model_is_stale(m)) {
+      design_list[[i]]$model <- refresh_model(m, attr(design_list[[i]], "p_vector"))
+    }
+  }
+  design_list
+}
+
 #' Update EMC Objects to the Current Version
 #'
 #' This function updates EMC objects created with older versions of the package to be compatible with the current version.
@@ -1316,42 +1406,33 @@ dm_list <- function(dadm)
 update2version <- function(emc){
   # For older versions, ensure that the class is emc:
   class(emc) <- "emc"
-  get_new_model <- function(old_model, pars){
-    if(old_model()$c_name == "LBA"){
-      model <- LBA
-    } else if(old_model()$c_name == "DDM"){
-      model <- DDM
-    } else if(old_model()$c_name == "RDM"){
-      model <- RDM
-    } else if(old_model()$c_name == "LNR"){
-      model <- LNR
-    } else{
-      stop("current model not supported for updating, sorry!!")
-    }
-    model_list <- model()
-    model_list$transform <- fill_transform(transform = old_model()$transform,model)
-    model_list$pre_transform <- fill_transform(transform = old_model()$pre_transform, model = model, p_vector = pars, is_pre = TRUE)
-    model_list$bound <- fill_bound(bound = NULL,model)
-    model <- function(){return(model_list)}
-    return(model)
-  }
+  get_new_model <- function(old_model, pars) refresh_model(old_model, pars, force = TRUE)
 
   new_expand <- function(x){
-    if(!is.null(x$winner)){
-      old_exp <- attr(x, "expand")
-      if(length(unique(old_exp) != length(unique(x$winner)))){
-        # In older versions we were working with a different expand version
-        new_x <- x[old_exp,]
-        new_x <- new_x[new_x$winner,]
-
-        reduced <- unique(new_x)       # keeps the first appearance of every row
-
-        ## ——— 2. create the “expand” index ———
-        key_full    <- do.call(paste, c(new_x,      sep = "\r"))   # one string per row
-        key_reduced <- do.call(paste, c(reduced, sep = "\r"))   # the same for reduced
-        attr(x, "expand") <- match(key_full, key_reduced)
-      }
+    # Before 474bba52 (April 2025) attr(x, "expand") indexed every row of the
+    # compressed dadm, so x[expand, ] rebuilt all accumulator rows of every
+    # trial. Since then, for race models (lR present), it indexes only the
+    # winner rows: x[x$winner, ][expand, ] is the data, one row per trial.
+    # Objects already in the new convention must be left alone: applying the
+    # conversion to them picks a mixture of winner and loser rows and silently
+    # drops about half of the trials.
+    old_exp <- attr(x, "expand")
+    if (is.null(x$winner) || is.null(x$lR) || is.null(old_exp)) return(x)
+    n_acc <- length(unique(x$lR))
+    n_win <- sum(x$winner)
+    if (n_acc < 2 || max(old_exp) <= n_win) return(x)  # new convention (or nothing to expand)
+    # Old convention: every compressed row is referenced, so max(expand) == nrow(x) > n_win.
+    full <- x[old_exp, , drop = FALSE]
+    if (length(old_exp) %% n_acc != 0 || sum(full$winner) != length(old_exp) / n_acc) {
+      stop("Cannot convert the stored 'expand' index of the data to the current convention")
     }
+    full <- full[full$winner, , drop = FALSE]
+    winners <- x[x$winner, , drop = FALSE]
+    key_full    <- do.call(paste, c(full,    sep = "\r"))   # one string per trial
+    key_reduced <- do.call(paste, c(winners, sep = "\r"))   # one per compressed winner row
+    new_exp <- match(key_full, key_reduced)
+    if (anyNA(new_exp)) stop("Cannot convert the stored 'expand' index of the data to the current convention")
+    attr(x, "expand") <- new_exp
     return(x)
   }
   update_expand <- function(emc){

--- a/R/make_data.R
+++ b/R/make_data.R
@@ -253,13 +253,18 @@ make_data <- function(parameters,design = NULL,n_trials=NULL,data=NULL,expand=1,
       }
     }
 
-    pars <- model()$Ttransform(pars, data)
+    # Bounds are checked on the model parameters *before* Ttransform, as the
+    # sampler does (c_do_bound in calc_ll): Ttransform may rewrite a bounded
+    # parameter in place (e.g. the DDM's SZ), and checking the derived value
+    # would reject draws the sampler accepted.
     if (!is.null(optionals$nobound)) {
-      attr(pars,"ok") <- rep(TRUE,nrow(pars))
+      pars_ok <- rep(TRUE,nrow(pars))
     } else {
       pars <- fix_bound(pars, model()$bound, data$lR,fix=!is.null(optionals$shrink2bound))
+      pars_ok <- attr(pars, 'ok')
     }
-    pars_ok <- attr(pars, 'ok')
+    pars <- model()$Ttransform(pars, data)
+    attr(pars, "ok") <- pars_ok
     if(mean(!pars_ok) > .1){
       warning("More than 10% of parameter values fall out of model bounds, see <model_name>$bounds()")
       return(FALSE)

--- a/R/model_DDM.R
+++ b/R/model_DDM.R
@@ -55,8 +55,13 @@ rDDM <- function(R,pars,ok=rep(TRUE,length(R)), precision=5e-3)
   unsim <- ok & !(is.finite(a_s) & a_s <= 1e3 &
                   is.finite(pars[, "v"] / pars[, "s"]) & is.finite(pars[, "sv"] / pars[, "s"]))
   if (any(unsim)) {
-    warning(sum(unsim), " trial(s) have a/s > 1000 (s close to 0?), which the Wiener sampler ",
-            "cannot simulate; they are returned as NA")
+    msg <- paste0(sum(unsim), " of ", n, " trial(s) have a/s > 1000 (s close to 0?), which the ",
+                  "Wiener sampler cannot simulate")
+    # Same rule as make_data() applies to out-of-bound parameters: a few such
+    # trials become NA, more than 10% is a refusal (warnings raised inside
+    # predict()'s forked workers never reach the caller, an error does)
+    if (mean(unsim) > .1) stop(msg)
+    warning(msg, "; they are returned as NA")
     ok[unsim] <- FALSE
   }
   pars <- as.matrix(pars[ok,,drop=FALSE])

--- a/R/model_DDM.R
+++ b/R/model_DDM.R
@@ -47,6 +47,18 @@ rDDM <- function(R,pars,ok=rep(TRUE,length(R)), precision=5e-3)
          " (", paste(R_levels, collapse = ", "), ")")
   n <- nrow(pars)
   out <- data.frame(R = rep(NA_character_, n), rt = rep(NA_real_, n))
+  # WienR::rWDM() does not terminate (uninterruptibly, in compiled code) once the
+  # boundary separation in diffusion units, a/s, exceeds ~1e4 -- and it is called
+  # inside suppress_output(), so nothing is visible. Fits whose s has collapsed
+  # towards 0 produce a/s ~ 1e9. Treat such trials as out of bounds instead.
+  a_s <- pars[, "a"] / pars[, "s"]
+  unsim <- ok & !(is.finite(a_s) & a_s <= 1e3 &
+                  is.finite(pars[, "v"] / pars[, "s"]) & is.finite(pars[, "sv"] / pars[, "s"]))
+  if (any(unsim)) {
+    warning(sum(unsim), " trial(s) have a/s > 1000 (s close to 0?), which the Wiener sampler ",
+            "cannot simulate; they are returned as NA")
+    ok[unsim] <- FALSE
+  }
   pars <- as.matrix(pars[ok,,drop=FALSE])
   if (nrow(pars) > 0) {
     # DDM gets unhappy with large trial numbers so split them into separate lists

--- a/R/model_DDM.R
+++ b/R/model_DDM.R
@@ -39,30 +39,38 @@ suppress_output <- function(expr) {
 
 rDDM <- function(R,pars,ok=rep(TRUE,length(R)), precision=5e-3)
 {
-  pars <- pars[ok,,drop=FALSE]
-  R <- R[ok]
-  pars <- as.matrix(pars);
-  # DDM gets unhappy with large trial numbers so split them into separate lists
-  split_idx <- rep(1:ceiling(nrow(pars)/5e3), each = 5e3)
-  split_idx <- split_idx[1:nrow(pars)]
-  out_list <- vector("list", length(unique(split_idx)))
-  for(j in 1:length(unique(split_idx))){
-    pars_tmp <- pars[split_idx == j,,drop=FALSE]
-    idx <- find_duplicate_indices(pars_tmp)
-    out <- data.frame(R = rep(NA,nrow(pars_tmp)), rt = rep(NA,nrow(pars_tmp)))
-    for(id in unique(idx)){
-      is_id <- which(idx == id)
-      cur_pars <- pars_tmp[is_id[1],]
-      tmp <- suppress_output(rWDM(N = length(is_id), a = cur_pars["a"]/cur_pars[ "s"], v = cur_pars["v"]/cur_pars[ "s"], t0 = cur_pars["t0"],
-                                  w = cur_pars["Z"], sw = cur_pars["SZ"], sv = cur_pars["sv"]/cur_pars[ "s"],
-                                  st0 = cur_pars["st0"], precision = precision, method="p-ars"))
-      tmp <- data.frame(R = tmp$response, rt = tmp$q)
-      out[is_id,] <- tmp
+  # One output row per input row (make_data() assigns the result column-wise
+  # into the trial data); trials with out-of-bound parameters get NA, as in rLBA.
+  R_levels <- levels(R)
+  if (length(R_levels) != 2)
+    stop("The DDM requires exactly two response levels; R has ", length(R_levels),
+         " (", paste(R_levels, collapse = ", "), ")")
+  n <- nrow(pars)
+  out <- data.frame(R = rep(NA_character_, n), rt = rep(NA_real_, n))
+  pars <- as.matrix(pars[ok,,drop=FALSE])
+  if (nrow(pars) > 0) {
+    # DDM gets unhappy with large trial numbers so split them into separate lists
+    split_idx <- rep(1:ceiling(nrow(pars)/5e3), each = 5e3)
+    split_idx <- split_idx[1:nrow(pars)]
+    out_list <- vector("list", length(unique(split_idx)))
+    for(j in 1:length(unique(split_idx))){
+      pars_tmp <- pars[split_idx == j,,drop=FALSE]
+      idx <- find_duplicate_indices(pars_tmp)
+      out_j <- data.frame(R = rep(NA_character_,nrow(pars_tmp)), rt = rep(NA_real_,nrow(pars_tmp)))
+      for(id in unique(idx)){
+        is_id <- which(idx == id)
+        cur_pars <- pars_tmp[is_id[1],]
+        tmp <- suppress_output(rWDM(N = length(is_id), a = cur_pars["a"]/cur_pars[ "s"], v = cur_pars["v"]/cur_pars[ "s"], t0 = cur_pars["t0"],
+                                    w = cur_pars["Z"], sw = cur_pars["SZ"], sv = cur_pars["sv"]/cur_pars[ "s"],
+                                    st0 = cur_pars["st0"], precision = precision, method="p-ars"))
+        tmp <- data.frame(R = tmp$response, rt = tmp$q)
+        out_j[is_id,] <- tmp
+      }
+      out_list[[j]] <- out_j
     }
-    out_list[[j]] <- out
+    out[ok,] <- do.call(rbind, out_list)
   }
-  out <- do.call(rbind, out_list)
-  out$R <- factor(out$R, labels = levels(R), levels = c("lower", "upper"))
+  out$R <- factor(out$R, labels = R_levels, levels = c("lower", "upper"))
   return(out)
 }
 

--- a/R/model_LBA.R
+++ b/R/model_LBA.R
@@ -138,7 +138,7 @@ rLBA <- function(lR,pars,p_types=c("v","sv","b","A","t0"),posdrift = TRUE,
   nr <- length(levels(lR))
   dt <- matrix(Inf,nrow=nr,ncol=nrow(pars)/nr)
   t0 <- pars[,"t0"]
-  pars <- pars[ok,]
+  pars <- pars[ok,,drop=FALSE]
   if (!all(p_types %in% dimnames(pars)[[2]]))
     stop("pars must have columns ",paste(p_types,collapse = " "))
   dt[ok] <- (pars[,"b"]-pars[,"A"]*runif(dim(pars)[1]))/

--- a/R/model_LNR.R
+++ b/R/model_LNR.R
@@ -24,13 +24,16 @@ rLNR <- function(lR,pars,p_types=c("m","s","t0"),ok=rep(TRUE,dim(pars)[1])){
   nr <- length(levels(lR))
   dt <- matrix(Inf,ncol=nrow(pars)/nr,nrow=nr)
   t0 <- pars[,"t0"]
-  pars <- pars[ok,]
+  pars <- pars[ok,,drop=FALSE]
   dt[ok] <- stats::rlnorm(dim(pars)[1],meanlog=pars[,"m"],sdlog=pars[,"s"])
   R <- apply(dt,2,which.min)
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   # Any t0 difference with lR due to response production time (no effect on race)
   rt <- matrix(t0,nrow=nr)[pick] + dt[pick]
-  R <- factor(levels(lR)[R],levels=levels(lR))
+  # Trials with out-of-bound parameters stay NA (as in rLBA)
+  ok <- matrix(ok,nrow=nr)[1,]
+  R <- factor(ifelse(ok, levels(lR)[R], NA),levels=levels(lR))
+  rt[!ok] <- NA
   cbind.data.frame(R=R,rt=rt)
 }
 

--- a/R/model_RDM.R
+++ b/R/model_RDM.R
@@ -290,15 +290,17 @@ rRDM <- function(lR,pars,p_types=c("v","B","A","t0"),ok=rep(TRUE,dim(pars)[1]))
   nr <- length(levels(lR))
   dt <- matrix(Inf,nrow=nr,ncol=nrow(pars)/nr)
   t0 <- pars[,"t0"]
-  pars <- pars[ok,]
+  pars <- pars[ok,,drop=FALSE]
   dt[ok] <- rWald(sum(ok),B=pars[,"B"],v=pars[,"v"],A=pars[,"A"])
   R <- apply(dt,2,which.min)
   pick <- cbind(R,1:dim(dt)[2]) # Matrix to pick winner
   # Any t0 difference with lR due to response production time (no effect on race)
   rt <- matrix(t0,nrow=nr)[pick] + dt[pick]
-  out$R <- levels(lR)[R]
+  # Trials with out-of-bound parameters stay NA (as in rLBA)
+  ok <- matrix(ok,nrow=nr)[1,]
+  out$R[ok] <- levels(lR)[R][ok]
   out$R <- factor(out$R,levels=levels(lR))
-  out$rt <- rt
+  out$rt[ok] <- rt[ok]
   out
 }
 

--- a/R/s3_funcs.R
+++ b/R/s3_funcs.R
@@ -167,6 +167,10 @@ predict.emc <- function(object,hyper=FALSE,n_post=50,n_cores=1,
     data <- get_data(emc)
   }
   design <- get_design(emc)
+  if (emc_has_stale_model(emc)) {
+    message("This object was fitted with an older EMC2; its model was refreshed for prediction. ",
+            "Run update2version() on the object to make this permanent.")
+  }
   return_trialwise_parameters <- isTRUE(dots$return_trialwise_parameters)
   if (is.null(dots$conditional_on_data) && has_conditional_covariates(design[[1]])) {
     dots$conditional_on_data <- FALSE
@@ -226,15 +230,21 @@ To override this behavior, pass `conditional_on_data=TRUE` to predict().')
     simDat <- suppressWarnings(mclapply(1:n_post,function(i){
       do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]]), fix_dots(dots, make_data)))
     },mc.cores=n_cores))
+    # make_data() returns FALSE when > 10% of a draw's trial-wise parameters
+    # fall outside the model bounds; replace such draws by other posterior draws
     in_bounds <- !sapply(simDat, is.logical)
     if(all(!in_bounds)) stop("All samples fall outside of model bounds")
+    post_idx <- 1:n_post
     if(any(!in_bounds)){
-      good_post <- sample(1:n_post, sum(!in_bounds))
+      good_post <- sample(which(in_bounds), sum(!in_bounds), replace = TRUE)
       simDat[!in_bounds] <- suppressWarnings(mclapply(good_post,function(i){
-        do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]], check_bounds = TRUE), fix_dots(dots, make_data)))
+        do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]]), fix_dots(dots, make_data)))
       },mc.cores=n_cores))
+      post_idx[!in_bounds] <- good_post
     }
-    out <- cbind(postn=rep(1:n_post,times=unlist(lapply(simDat,function(x)dim(x)[1]))),do.call(rbind,simDat))
+    still_in_bounds <- !sapply(simDat, is.logical)
+    out <- cbind(postn=rep(post_idx[still_in_bounds],times=unlist(lapply(simDat[still_in_bounds],function(x)dim(x)[1]))),
+                 do.call(rbind,simDat[still_in_bounds]))
     if (n_post==1) pars <- pars[[1]]
     attr(out,"pars") <- pars
     if(return_trialwise_parameters) attr(out, 'trialwise_parameters') <- lapply(simDat, function(x) attr(x, "trialwise_parameters"))
@@ -1166,6 +1176,10 @@ get_design.emc <- function(x){
   } else{
     emc_design <- get_design(get_prior(x))
   }
+  # Objects fitted before May 2025 carry a model closure with the old
+  # rfun(lR, pars) interface; refresh it (in memory) so the design is usable
+  # by make_data()/predict(). update2version() makes this permanent.
+  emc_design <- refresh_design_models(emc_design)
   class(emc_design) <- "emc.design"
   return(emc_design)
 }

--- a/R/s3_funcs.R
+++ b/R/s3_funcs.R
@@ -233,7 +233,8 @@ To override this behavior, pass `conditional_on_data=TRUE` to predict().')
     # make_data() returns FALSE when > 10% of a draw's trial-wise parameters
     # fall outside the model bounds; replace such draws by other posterior draws
     in_bounds <- !sapply(simDat, is.logical)
-    if(all(!in_bounds)) stop("All samples fall outside of model bounds")
+    if(all(!in_bounds)) stop("All samples fall outside of model bounds, or could not be simulated ",
+                             "(call make_data() on one posterior draw to see the warnings)")
     post_idx <- 1:n_post
     if(any(!in_bounds)){
       good_post <- sample(which(in_bounds), sum(!in_bounds), replace = TRUE)

--- a/R/s3_funcs.R
+++ b/R/s3_funcs.R
@@ -227,23 +227,28 @@ To override this behavior, pass `conditional_on_data=TRUE` to predict().')
         }
       }
     }
-    simDat <- suppressWarnings(mclapply(1:n_post,function(i){
-      do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]]), fix_dots(dots, make_data)))
-    },mc.cores=n_cores))
+    sim_one <- function(i) tryCatch(
+      do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]]), fix_dots(dots, make_data))),
+      error = function(e) e)
+    simDat <- suppressWarnings(mclapply(1:n_post, sim_one, mc.cores=n_cores))
     # make_data() returns FALSE when > 10% of a draw's trial-wise parameters
-    # fall outside the model bounds; replace such draws by other posterior draws
-    in_bounds <- !sapply(simDat, is.logical)
-    if(all(!in_bounds)) stop("All samples fall outside of model bounds, or could not be simulated ",
-                             "(call make_data() on one posterior draw to see the warnings)")
+    # fall outside the model bounds, and an rfun may refuse a draw it cannot
+    # simulate (returned as a condition from the worker); replace such draws by
+    # other posterior draws
+    failed <- sapply(simDat, function(x) is.logical(x) || inherits(x, "condition") || inherits(x, "try-error"))
+    in_bounds <- !failed
+    if(all(!in_bounds)) {
+      errs <- unique(unlist(lapply(simDat, function(x) if (inherits(x, "condition")) conditionMessage(x))))
+      stop("All samples fall outside of model bounds, or could not be simulated",
+           if (length(errs)) paste0(": ", paste(errs, collapse = " | ")) else "")
+    }
     post_idx <- 1:n_post
     if(any(!in_bounds)){
       good_post <- sample(which(in_bounds), sum(!in_bounds), replace = TRUE)
-      simDat[!in_bounds] <- suppressWarnings(mclapply(good_post,function(i){
-        do.call(make_data, c(list(pars[[i]],design=design[[j]],data=data[[j]]), fix_dots(dots, make_data)))
-      },mc.cores=n_cores))
+      simDat[!in_bounds] <- suppressWarnings(mclapply(good_post, sim_one, mc.cores=n_cores))
       post_idx[!in_bounds] <- good_post
     }
-    still_in_bounds <- !sapply(simDat, is.logical)
+    still_in_bounds <- !sapply(simDat, function(x) is.logical(x) || inherits(x, "condition") || inherits(x, "try-error"))
     out <- cbind(postn=rep(post_idx[still_in_bounds],times=unlist(lapply(simDat[still_in_bounds],function(x)dim(x)[1]))),
                  do.call(rbind,simDat[still_in_bounds]))
     if (n_post==1) pars <- pars[[1]]

--- a/R/trend.R
+++ b/R/trend.R
@@ -1741,15 +1741,18 @@ make_data_unconditional <- function(data, pars, design, model,
         attr(pm, "trialwise_parameters") <- covariates
       }
 
-      # 7. Ttransform + bounds on current-trial rows only
-      pr <- model_list$Ttransform(pm[idx_curr, , drop = FALSE], dadm_current)
-
+      # 7. Bounds (before Ttransform, as the sampler does) + Ttransform on
+      #    current-trial rows only
+      pr <- pm[idx_curr, , drop = FALSE]
       if (!is.null(optionals$nobound)) {
-        attr(pr, "ok") <- rep(TRUE, nrow(pr))
+        pr_ok <- rep(TRUE, nrow(pr))
       } else {
         pr <- fix_bound(pr, model_list$bound, dadm_current$lR,
                         fix = !is.null(optionals$shrink2bound))
+        pr_ok <- attr(pr, "ok")
       }
+      pr <- model_list$Ttransform(pr, dadm_current)
+      attr(pr, "ok") <- pr_ok
 
       # 8. Simulate R and rt
       if (any(names(dadm_current) == "RACE")) {

--- a/tests/testthat/test-predict_legacy.R
+++ b/tests/testthat/test-predict_legacy.R
@@ -1,0 +1,103 @@
+# predict() on objects fitted with older EMC2 versions, and the row-preservation
+# guarantees it relies on. See update2version() / refresh_model() in design.R.
+
+# Emulate a fit whose model closure was frozen before May 2025: rfun(lR, pars)
+make_stale <- function(emc) {
+  pr <- get_prior(emc)
+  des <- attr(pr, "design")
+  ml <- des[[1]]$model()
+  ml$rfun <- function(lR, pars) rLNR(lR, pars, ok = attr(pars, "ok"))
+  ml$bound$minmax[, "t0"] <- c(0.1, Inf)          # a fit-time custom bound to preserve
+  des[[1]]$model <- function() ml
+  attr(pr, "design") <- des
+  emc <- lapply(emc, function(x) { x$prior <- pr; x })
+  emc[[1]]$model <- function() ml
+  class(emc) <- "emc"
+  emc
+}
+
+test_that("stale model closures are detected and refreshed for predict()", {
+  stale <- make_stale(samples_LNR)
+  expect_false(emc_has_stale_model(samples_LNR))
+  expect_true(emc_has_stale_model(stale))
+  # get_design() hands back a usable design without touching the object
+  d <- get_design(stale)
+  expect_identical(names(formals(d[[1]]$model()$rfun))[1], "data")
+  expect_equal(d[[1]]$model()$bound$minmax[, "t0"], c(0.1, Inf))
+  expect_true(emc_has_stale_model(stale))
+  set.seed(1)
+  expect_message(p <- predict(stale, n_post = 2), "update2version")
+  expect_equal(nrow(p), 2 * nrow(get_data(stale)))
+})
+
+test_that("update2version() keeps one predicted row per trial and the stored bound", {
+  for (obj in list(samples_LNR, make_stale(samples_LNR))) {
+    up <- update2version(obj)
+    expect_false(emc_has_stale_model(up))
+    expect_equal(nrow(get_data(up)), nrow(get_data(samples_LNR)))
+    expect_equal(attr(up[[1]]$data[[1]], "expand"), attr(samples_LNR[[1]]$data[[1]], "expand"))
+    set.seed(2)
+    expect_equal(nrow(predict(up, n_post = 1)), nrow(get_data(up)))
+  }
+  up <- update2version(make_stale(samples_LNR))
+  expect_equal(get_design(up)[[1]]$model()$bound$minmax[, "t0"], c(0.1, Inf))
+})
+
+test_that("update2version() converts the pre-2025 all-rows expand convention", {
+  x <- samples_LNR[[1]]$data[[1]]
+  new_exp <- attr(x, "expand")
+  # Rebuild the old index: every row of the compressed dadm, trial by trial
+  win_rows <- which(x$winner)
+  old_exp <- as.vector(vapply(new_exp, function(w) {
+    tr <- x$trials[win_rows[w]]; s <- x$subjects[win_rows[w]]
+    which(x$trials == tr & x$subjects == s)
+  }, numeric(length(unique(x$lR)))))
+  expect_gt(max(old_exp), sum(x$winner))
+  old <- samples_LNR
+  attr(old[[1]]$data[[1]], "expand") <- old_exp
+  up <- update2version(old)
+  expect_equal(attr(up[[1]]$data[[1]], "expand"), new_exp)
+})
+
+test_that("rfuns return one row per trial with NA for out-of-bound trials", {
+  lR <- factor(rep(c("left", "right"), 5), levels = c("left", "right"))
+  # LNR / RDM: 2 accumulators x 5 trials; trial 3 out of bounds
+  ok <- rep(TRUE, 10); ok[5:6] <- FALSE
+  p_lnr <- cbind(m = rep(0, 10), s = 1, t0 = .2)
+  r <- rLNR(lR, p_lnr, ok = ok)
+  expect_equal(nrow(r), 5); expect_true(is.na(r$rt[3])); expect_true(is.na(r$R[3]))
+  expect_true(all(is.finite(r$rt[-3])))
+  p_rdm <- cbind(v = rep(2, 10), B = 1, A = 0, t0 = .2, s = 1)
+  r <- rRDM(lR, p_rdm, ok = ok)
+  expect_equal(nrow(r), 5); expect_true(is.na(r$rt[3])); expect_true(is.na(r$R[3]))
+  # DDM: one row per trial, trials 2 and 4 out of bounds
+  R <- factor(rep("left", 5), levels = c("left", "right"))
+  p_ddm <- cbind(v = rep(1, 5), a = 1, sv = 0, t0 = .2, st0 = 0, s = 1, Z = .5, SZ = 0)
+  r <- rDDM(R, p_ddm, ok = c(TRUE, FALSE, TRUE, FALSE, TRUE))
+  expect_equal(nrow(r), 5)
+  expect_equal(is.na(r$rt), c(FALSE, TRUE, FALSE, TRUE, FALSE))
+  expect_equal(levels(r$R), c("left", "right"))
+  expect_error(rDDM(factor(1:3), p_ddm[1:3, ]), "exactly two response levels")
+})
+
+test_that("design() refuses a DDM with more than two response levels", {
+  dat <- forstmann
+  levels(dat$R) <- c("left", "right")
+  dat$R <- factor(as.character(dat$R), levels = c("left", "right", "none"))
+  expect_error(design(data = dat, model = DDM, formula = list(v ~ 1, a ~ 1, t0 ~ 1)),
+               "exactly two response levels")
+  dat$R <- droplevels(dat$R)
+  expect_s3_class(design(data = dat, model = DDM, formula = list(v ~ 1, a ~ 1, t0 ~ 1),
+                         report_p_vector = FALSE), "emc.design")
+})
+
+test_that("make_data() checks bounds before Ttransform, as the sampler does", {
+  des <- design(data = forstmann, model = DDM, formula = list(v ~ 1, a ~ 1, t0 ~ 1, Z ~ 1, SZ ~ 1),
+                report_p_vector = FALSE)
+  # SZ = .015 is inside the (.01, .99) bound the sampler checks, but the derived
+  # 2 * SZ * min(Z, 1 - Z) = .009 fails it if checked after Ttransform
+  p <- c(v = 1, a = log(1), t0 = log(.2), Z = qnorm(.3), SZ = qnorm(.015))
+  d <- make_data(p, des, data = forstmann)
+  expect_s3_class(d, "data.frame")
+  expect_equal(nrow(d), nrow(forstmann))
+})

--- a/tests/testthat/test-predict_legacy.R
+++ b/tests/testthat/test-predict_legacy.R
@@ -106,8 +106,17 @@ test_that("rDDM() refuses a/s beyond what rWDM can simulate instead of hanging",
   R <- factor(rep("left", 6), levels = c("left", "right"))
   p <- cbind(v = rep(1, 6), a = 1, sv = 0.5, t0 = .2, st0 = 0, s = c(1, 1, 1, 1e-4, 1e-10, 1), Z = .5, SZ = 0.1)
   setTimeLimit(elapsed = 20, transient = TRUE)
-  expect_warning(r <- rDDM(R, p), "a/s > 1000")
+  expect_error(rDDM(R, p), "a/s > 1000")               # 2 of 6 > 10%: refused
+  p20 <- p[rep(1, 20), ]; p20[3, "s"] <- 1e-10          # 1 of 20: NA + warning
+  expect_warning(r <- rDDM(factor(rep("left", 20), levels = c("left", "right")), p20), "a/s > 1000")
   setTimeLimit()
-  expect_equal(nrow(r), 6)
-  expect_equal(is.na(r$rt), c(FALSE, FALSE, FALSE, TRUE, TRUE, FALSE))
+  expect_equal(nrow(r), 20)
+  expect_equal(which(is.na(r$rt)), 3L)
+})
+
+test_that("predict() reports a draw its rfun refuses instead of returning NA rows", {
+  des <- design(data = forstmann, model = DDM, formula = list(v ~ 1, a ~ 1, t0 ~ 1, s ~ E),
+                report_p_vector = FALSE)
+  p <- sampled_pars(des); p[] <- 0; p["a"] <- log(1); p["t0"] <- log(.2); p["s_Eneutral"] <- -25
+  expect_error(make_data(p, des, data = forstmann), "a/s > 1000")
 })

--- a/tests/testthat/test-predict_legacy.R
+++ b/tests/testthat/test-predict_legacy.R
@@ -101,3 +101,13 @@ test_that("make_data() checks bounds before Ttransform, as the sampler does", {
   expect_s3_class(d, "data.frame")
   expect_equal(nrow(d), nrow(forstmann))
 })
+
+test_that("rDDM() refuses a/s beyond what rWDM can simulate instead of hanging", {
+  R <- factor(rep("left", 6), levels = c("left", "right"))
+  p <- cbind(v = rep(1, 6), a = 1, sv = 0.5, t0 = .2, st0 = 0, s = c(1, 1, 1, 1e-4, 1e-10, 1), Z = .5, SZ = 0.1)
+  setTimeLimit(elapsed = 20, transient = TRUE)
+  expect_warning(r <- rDDM(R, p), "a/s > 1000")
+  setTimeLimit()
+  expect_equal(nrow(r), 6)
+  expect_equal(is.na(r$rt), c(FALSE, FALSE, FALSE, TRUE, TRUE, FALSE))
+})


### PR DESCRIPTION
## Summary

`predict()` failed on 114 of 343 archived fits (5 architectures x 3 tasks, produced over ~14 months across EMC2 versions). Four independent faults:

- **Stale model closure (stored state, 100 fits).** `design()` freezes `model()` into a closure that is serialised with the fit; fits from before 058ce1a9 (May 2025) carry `rfun(lR, pars)` while `make_data()` calls `rfun(data, pars)`. New `refresh_model()` rebuilds the closure from the live constructor (by `c_name`/`type`), keeping the fit-time `transform`, `pre_transform` and `bound`. `get_design.emc()` applies it in memory when the stored `rfun` has the old signature, so plain `predict()` works on untouched objects (one message pointing at `update2version()`); `update2version()` uses the same helper and makes it permanent.
- **`update2version()` silently dropped ~half the trials.** `new_expand()` tested `length(unique(old_exp) != ...)` (misplaced parenthesis, always TRUE) and applied the pre-474bba52 all-rows `expand` conversion to objects already in the winner-rows convention. Now detected structurally (`max(expand) > number of winner rows`) and indexed against the winner rows. It also reset custom bounds to the model default; now preserved.
- **`rDDM()` dropped out-of-bound rows (c711f098).** `make_data()` assigns the result column-wise into the trial data, so it needs one row per trial. `rDDM()` now returns NA for those rows, as `rLBA()` does; `rRDM()`/`rLNR()` brought in line (they returned level 1 / `rt = Inf`); `drop = FALSE` guards.
- **Bounds checked after `Ttransform` (consistency fix).** The sampler checks bounds on the raw model parameters (`c_do_bound` before the likelihood's own rescaling); `make_data()` checked them after `Ttransform`, and the DDM's `Ttransform` rewrites `SZ` in place, so draws the sampler accepted could be rejected at prediction. Now checked before `Ttransform` in both `make_data()` paths, so simulation is consistent with estimation. Established by argument and unit test rather than by an archive failure: the archive-wide run found no fit that needed it (the one "outside of model bounds" case was a degenerate fit, see below). `predict.emc()` also replaces out-of-bound draws with in-bound ones and drops any that still fail rather than erroring in `rbind`.
- `design()` refuses a DDM with != 2 response levels (a third level was silently fitted as the upper boundary; 6 archived fits are unusable for this reason).

## Test plan

- New `tests/testthat/test-predict_legacy.R` (33 checks): stale-closure detection/refresh with bound preserved, `update2version()` row criterion `nrow(predict(e, n_post = 1)) == nrow(get_data(e))` on healthy and stale objects, synthetic old-convention `expand` conversion, rfun row preservation, DDM level check, bounds-before-`Ttransform`.
- Full suite 203 passed / 0 failed; `devtools::check()` 0 errors, 0 new warnings/notes.
- **Archive-wide run (335 fits, read in place):** 329 predict successfully and every one returns exactly `nrow(get_data(emc))` rows via both the raw and the `update2version()` route (previously ~half on every object `update2version()` touched); the refresh message fires exactly once on the 97 stale fits; the 6 failures are exactly the three-level Stroop WDM/DDM fits, with the new message. One further fit (`Simon/DDM/DDM_avs`) is a degenerate posterior (`s` collapsed to ~1e-8 in one condition for all 518 subjects) and is excluded on those grounds.

Follow-up in progress (separate commit): `predict()` can hang inside `WienR::rWDM()` on one archived DDM fit with widely separated chains; a guard on the scaled arguments / a finite `bound` is being added once the offending call is captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)